### PR TITLE
Fix compiler warnings and modernize RNG usage across MD modules

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,25 +5,6 @@ The autocorrelation function is one of the most important statistical tools in m
 it tells you how many
 */
 
-use crate::lennard_jones_simulations::Particle;
-use crate::molecule;
-use crate::parameters;
-
-#[derive(Debug)]
-enum PropertyField {
-    Energy,
-}
-
-enum PropertyValue {
-    Number(f64),
-}
-
-fn get_property_value(field: Option<PropertyField>, particle: Particle) -> Option<f64> {
-    match field {
-        Some(PropertyField::Energy) => Some(particle.energy),
-        None => None,
-    }
-}
 
 pub fn compute_average_val(
     container_value: &mut Vec<f32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,6 @@ fn dedup_permutation(v: &mut Vec<Vec<i32>>) {
 
 pub mod cell_subdivision {
 
-    use super::*; //
     use nalgebra::Vector3;
     use crate::lennard_jones_simulations::Particle;
     use crate::molecule::molecule::System;
@@ -138,11 +137,6 @@ pub mod cell_subdivision {
 
     //fn cell_id_to_3d
 
-    fn distance_to(this: &Vector3<f64>, other: &Vector3<f64>) -> f64 {
-        // Calculate the distance using the Euclidean distance formula
-        ((this.x - other.x).powi(2) + (this.y - other.y).powi(2) + (this.z - other.z).powi(2))
-            .sqrt()
-    }
 
     fn position_to_cell_3d(
         pos: &Vector3<f64>,
@@ -322,7 +316,7 @@ pub mod lennard_jones_simulations {
 
     #[derive(Clone)]
     pub struct SimulationSummary {
-        energy: f64,
+        pub energy: f64,
     }
 
     pub enum InitOutput {
@@ -336,13 +330,13 @@ pub mod lennard_jones_simulations {
     }
 
     impl Particle {
-        fn distance(&self, other: &Particle) -> f64 {
+        pub fn distance(&self, other: &Particle) -> f64 {
             // Compute the distance between two particles
             (self.position - other.position).norm()
         }
 
         pub fn maxwellboltzmannvelocity(&mut self, temp: f64, mass: f64, _v_max: f64) {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
 
             // Standard deviation based on MB distribution
             let sigma_mb = (temp / mass).sqrt();
@@ -417,7 +411,7 @@ pub mod lennard_jones_simulations {
     }
 
     pub fn set_molecular_positions_and_velocities(system_mol: &mut InitOutput, temp: f64) -> () {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // loop over each moleucle
 
         // Create a normal distribution with mean = 0, std = sigma
@@ -467,7 +461,7 @@ pub mod lennard_jones_simulations {
          */
         let mut vector_positions: Vec<Particle> = Vec::new();
         let mut vector_system_positions: Vec<System> = Vec::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // Create the number of atoms in the system with the system as necessary
         if !use_atom {
             for index in 0..number_of_atoms {
@@ -662,11 +656,11 @@ pub mod lennard_jones_simulations {
         // loop over the cells
         for cell_i in 0..cell_match_storage.len() {
             // select cell entry
-            let cell_I = cell_match_storage[cell_i][0];
-            let cell_II = cell_match_storage[cell_i][1];
+            let cell_i_idx = cell_match_storage[cell_i][0];
+            let cell_ii_idx = cell_match_storage[cell_i][1];
 
-            for i_index in cells[cell_I as usize].atom_index.iter() {
-                for j_index in cells[cell_II as usize].atom_index.iter() {
+            for i_index in cells[cell_i_idx as usize].atom_index.iter() {
+                for j_index in cells[cell_ii_idx as usize].atom_index.iter() {
                     let r_vec = particles[*i_index].position - particles[*j_index].position;
                     let r_mic = minimum_image_convention(r_vec, box_length);
                     let r = r_mic.norm(); // compute the distance
@@ -1122,7 +1116,7 @@ pub mod lennard_jones_simulations {
             probability ~ nu * dt ( valid when nu * dt is small; otherwise use 1 - exp(-nu * dt)
              */
 
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let p_coll = nu * dt;
 
             for p in particles.iter_mut() {
@@ -1398,7 +1392,7 @@ mod tests {
     // lennard-jones double loop test
     #[test]
     fn test_double_loop() {
-        let lj_params = lennard_jones_simulations::LJParameters {
+        let _lj_params = lennard_jones_simulations::LJParameters {
             epsilon: 1.0,
             sigma: 1.0,
             number_of_atoms: 2,
@@ -1411,9 +1405,9 @@ mod tests {
 
     #[test]
     fn test_lennard_jones() {
-        let sigma = 1.0;
-        let epsilon = 1.0;
-        let lj_params_new = lennard_jones_simulations::LJParameters {
+        let _sigma = 1.0;
+        let _epsilon = 1.0;
+        let _lj_params_new = lennard_jones_simulations::LJParameters {
             epsilon: 1.0,
             sigma: 1.0,
             number_of_atoms: 10,
@@ -1446,7 +1440,7 @@ mod tests {
 
         let dof = match &new_simulation_md {
             lennard_jones_simulations::InitOutput::Particles(particles) => 3 * particles.len(),
-            &lennard_jones_simulations::InitOutput::Systems(systems) => {
+            lennard_jones_simulations::InitOutput::Systems(systems) => {
                 3 * systems.iter().map(|sys| sys.atoms.len()).sum::<usize>()
             }
         };

--- a/src/molecule/molecule.rs
+++ b/src/molecule/molecule.rs
@@ -12,7 +12,6 @@ use crate::lennard_jones_simulations::LJParameters;
 use crate::lennard_jones_simulations::Particle;
 
 use nalgebra::Vector3;
-use std::collections::{HashMap, HashSet};
 
 #[derive(Copy, Clone)]
 pub struct SimpleBond {
@@ -84,14 +83,6 @@ pub struct System {
     pub bonds: Vec<Bond>,
 }
 
-fn safe_norm(v: &Vector3<f64>) -> f64 {
-    let r = v.norm();
-    if r < 1e-12 {
-        1e-12
-    } else {
-        r
-    }
-}
 
 // System is all the atoms (global), bonded terms in global indices, and exclusion sets
 
@@ -113,7 +104,7 @@ pub fn compute_bond_force(atoms: &mut Vec<Particle>, bond: &Bond, box_length: f6
     0.5 * bond.k * dr * dr // return the bond energy
 }
 
-pub fn compute_electostatic_bond_short_force(atoms: &mut Vec<Particle>, box_length: f64) -> f64 {
+pub fn compute_electostatic_bond_short_force(atoms: &mut Vec<Particle>, _box_length: f64) -> f64 {
     /*
     Compute the short range real space component of the electrostatic interaction
 
@@ -123,7 +114,6 @@ pub fn compute_electostatic_bond_short_force(atoms: &mut Vec<Particle>, box_leng
 
      */
     let mut total_short_range_potential = 0.0;
-    let k_2 = 1.0; // This will be changed to the permittivity of free space
     let e_0 = 1.0;
     for i in 0..atoms.len() {
         for j in (i + 1)..atoms.len() {

--- a/src/parameters/lj_parameters.rs
+++ b/src/parameters/lj_parameters.rs
@@ -24,14 +24,12 @@ pub fn hard_sphere_potential(r: f64, sigma: f64) -> f64 {
     /*
     Return the hard-sphere potential
      */
-    let mut u_ij = 0.0;
     if r < 1e-9 {
         return 0.0;
     } // Avoid singularity
     if r < sigma {
-        u_ij = 1000000000000000000000.0; // meant to simulate infinity..
+        1000000000000000000000.0 // meant to simulate infinity..
     } else {
-        u_ij = 0.0; // need to be a floating point number
+        0.0 // need to be a floating point number
     }
-    u_ij
 }

--- a/src/thermostat_barostat/andersen.rs
+++ b/src/thermostat_barostat/andersen.rs
@@ -2,8 +2,7 @@ pub mod andersen {
 
     use crate::cell_subdivision;
     use crate::lennard_jones_simulations::{compute_forces_particles, Particle};
-    use nalgebra::{zero, Vector3};
-    use rand::prelude::*;
+    use nalgebra::Vector3;
     use rand::Rng;
     use rand_distr::{Distribution, Normal};
 
@@ -17,9 +16,6 @@ pub mod andersen {
         /*
         Initialize system and compute the forces and energy
          */
-        let mut t = 0.0;
-        let mut switch = 1;
-
         while target_temperature < t_max {
             // Propagates the half step
             //run_md_andersen_particles(particles, dt, box_length, target_temperature, 1.0, switch);
@@ -108,7 +104,7 @@ pub mod andersen {
             /*
             Forces should be recomputed BEFORE this half-kikc
              */
-            let mut simulation_box = cell_subdivision::SimulationBox {
+            let simulation_box = cell_subdivision::SimulationBox {
                 x_dimension: _box_length,
                 y_dimension: _box_length,
                 z_dimension: _box_length,

--- a/src/thermostat_barostat/berendsen.rs
+++ b/src/thermostat_barostat/berendsen.rs
@@ -1,13 +1,9 @@
 pub mod berendsen {
 
-    use crate::cell_subdivision;
     use crate::lennard_jones_simulations::compute_pressure_particles; // using the compute_pressure_particles from lib.rs
     use crate::lennard_jones_simulations::Particle; // using the Particle struct from the lennard_jones_simulation mod from lib.rs
 
     // statistical modules
-    use rand::prelude::*;
-    use rand::Rng;
-    use rand_distr::{Distribution, Normal};
 
     pub fn apply_barostat_berendsen_particles(
         particles: &mut Vec<Particle>,

--- a/src/thermostat_barostat/nose_hoover.rs
+++ b/src/thermostat_barostat/nose_hoover.rs
@@ -1,13 +1,8 @@
 pub mod nose_hoover {
-    use crate::cell_subdivision;
     use crate::lennard_jones_simulations::{
-        compute_forces_particles, compute_pressure_particles, compute_temperature_particles,
+        compute_pressure_particles, compute_temperature_particles,
         Particle,
     };
-    use nalgebra::{zero, Vector3};
-    use rand::prelude::*;
-    use rand::Rng;
-    use rand_distr::{Distribution, Normal};
 
     pub fn apply_thermostat_nose_hoover_particles(
         particles: &mut Vec<Particle>,


### PR DESCRIPTION
### Motivation
- Silence a large set of compiler warnings (unused imports/vars, dead code, deprecated APIs) to improve code hygiene and make refactors safer. 
- Modernize RNG usage and fix a borrow/move error in a test to ensure tests compile and run reliably. 

### Description
- Removed dead/unused helper types and imports from `src/error.rs` and simplified the exported analysis functions. 
- Cleaned unused imports/locals and removed unused helper functions in molecular and thermostat modules, marked intentionally-unused parameters with a leading underscore (e.g. `_box_length`). 
- Replaced deprecated `rand::thread_rng()` calls with `rand::rng()`, removed unnecessary `mut` bindings, and renamed non-snake-case locals (`cell_I`/`cell_II` -> `cell_i_idx`/`cell_ii_idx`). 
- Simplified `hard_sphere_potential` to return directly instead of assigning to an unused mutable, made `SimulationSummary.energy` and `Particle::distance` public to avoid dead-code warnings, and fixed a test pattern-match to avoid moving out of a borrowed `InitOutput` while also prefixing unused test locals with `_`.

### Testing
- Ran `cargo check --tests`, which completed successfully. 
- Ran `cargo test --quiet -- --skip berenden_pull_towards_target`, which passed (4 tests passed, 0 failed). 
- The full `cargo test --quiet` includes a long-running test (`berenden_pull_towards_target`), so a targeted test run with that test skipped was used for fast verification and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af03a07c8832eb39bd34242b2dc01)