### PR TITLE
Replace print macros with structured logging and cleaner output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rand_distr = "0.5"
 nalgebra = "0.33"         # OR ndarray = "0.16" (pick one)
 itertools = "0.14"        # optional
 log = "0.4"               # optional
+env_logger = "0.11"
 assert-type-eq = "0.1.0"
 parameterized = "2.1.0"
 xdrfile = "0.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ The autocorrelation function is one of the most important statistical tools in m
 it tells you how many
 */
 
-
 pub fn compute_average_val(
     container_value: &mut Vec<f32>,
     block_steps: u64,
@@ -18,18 +17,16 @@ pub fn compute_average_val(
  */
 {
     if number_of_steps % block_steps != 0 {
-        eprintln!("We dont have the right number of blocks steps defined for the total number of steps {}", number_of_steps);
+        log::warn!("Invalid block configuration: number_of_steps={number_of_steps}, block_steps={block_steps}");
     }
     // ensure that the property we want to compute the block average for
     // actually exists within the simulation code
 
     for (i, chunk) in container_value.chunks(block_steps as usize).enumerate() {
         let summed_values: f32 = chunk.iter().sum();
-        println!(
-            "chunk {:?}: {:?} with block sizes as {:?}",
-            i,
-            summed_values / block_steps as f32,
-            block_steps
+        log::info!(
+            "Block {i:>4} | avg={:.6} (block size={block_steps})",
+            summed_values / block_steps as f32
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,9 @@ fn dedup_permutation(v: &mut Vec<Vec<i32>>) {
 
 pub mod cell_subdivision {
 
-    use nalgebra::Vector3;
     use crate::lennard_jones_simulations::Particle;
     use crate::molecule::molecule::System;
+    use nalgebra::Vector3;
     /*
     Create the subcells required for efficiently computing the intermolecular interactions
     within a certain radius cutoff rather than working with all the atoms in the system
@@ -136,7 +136,6 @@ pub mod cell_subdivision {
     }
 
     //fn cell_id_to_3d
-
 
     fn position_to_cell_3d(
         pos: &Vector3<f64>,
@@ -281,6 +280,7 @@ pub mod lennard_jones_simulations {
 
     use error::compute_average_val;
 
+    use log::{debug, error, info};
     use nalgebra::{zero, Vector3};
     use rand::Rng;
     use rand_distr::{Distribution, Normal};
@@ -349,7 +349,7 @@ pub mod lennard_jones_simulations {
             self.velocity[1] = normal.sample(&mut rng);
             self.velocity[2] = normal.sample(&mut rng);
 
-            println!("Assigned Maxwell-Boltzmann velocity: {:?}", self.velocity);
+            debug!("Assigned Maxwell-Boltzmann velocity: {:?}", self.velocity);
         }
 
         fn update_position_verlet(&mut self, dt: f64) -> () {
@@ -679,8 +679,8 @@ pub mod lennard_jones_simulations {
                     // action = -reaction
                     particles[*i_index].force -= f_vec;
                     particles[*j_index].force += f_vec;
-                    println!(
-                        "The forces are {:?} {:?}",
+                    debug!(
+                        "Pair force update: i={:?}, j={:?}",
                         particles[*i_index].force, particles[*j_index].force
                     );
                 }
@@ -874,8 +874,8 @@ pub mod lennard_jones_simulations {
                     p.velocity *= lambda;
                 }
 
-                println!(
-                    "Thermostat [Particles]: T = {:.2} -> {:.2}, λ = {:.4}",
+                info!(
+                    "Thermostat[particles] T: {:.2} -> {:.2} (scale λ={:.4})",
                     current_temperature, target_temperature, lambda
                 );
             }
@@ -904,8 +904,8 @@ pub mod lennard_jones_simulations {
                         a.velocity *= lambda;
                     }
 
-                    println!(
-                        "Thermostat [System #{si}]: T = {:.2} -> {:.2}, λ = {:.4}",
+                    info!(
+                        "Thermostat[system {si}] T: {:.2} -> {:.2} (scale λ={:.4})",
                         current_temperature, target_temperature, lambda
                     );
                 }
@@ -1054,8 +1054,8 @@ pub mod lennard_jones_simulations {
             }
         }
 
-        println!(
-            "The potential energy is {}",
+        debug!(
+            "Total instantaneous energy: {:.6}",
             kinetic_energy + potential_energy
         );
 
@@ -1168,9 +1168,9 @@ pub mod lennard_jones_simulations {
         let mut potential_energy = site_site_energy_calculation(particles, box_length);
         let mut total_energy = kinetic_energy + potential_energy;
 
-        println!(
-        "[init] E_kin = {kinetic_energy:.6}, E_pot = {potential_energy:.6}, E_tot = {total_energy:.6}"
-    );
+        info!(
+            "Init particle energy | E_kin={kinetic_energy:.6} E_pot={potential_energy:.6} E_tot={total_energy:.6}"
+        );
 
         // only used if we are using nose_hoover
         let mut xi_nose_hoover = 0.0;
@@ -1277,9 +1277,9 @@ pub mod lennard_jones_simulations {
         simulation_box.store_atoms_in_cells_systems(systems, &mut subcells, 10);
         // --- initial forces and energy ---
 
-        println!(
-        "[init systems] particle  E_kin = {kinetic_energy:.6}, E_pot = {potential_energy:.6}, E_tot = {total_energy:.6}"
-	);
+        info!(
+            "Init systems energy | E_kin={kinetic_energy:.6} E_pot={potential_energy:.6} E_tot={total_energy:.6}"
+        );
 
         for sys in systems.iter_mut() {
             for a in sys.atoms.iter_mut() {
@@ -1361,7 +1361,7 @@ pub mod lennard_jones_simulations {
 
             total_energy = kinetic_energy + potential_energy;
             values.push(total_energy as f32); // compute the total energy per timestep
-            println!("step {_step}: E_tot = {total_energy:.6}, E_kin = {kinetic_energy:.6}, E_pot = {potential_energy:.6}");
+            info!("Step {_step:>4} | E_tot={total_energy:.6} E_kin={kinetic_energy:.6} E_pot={potential_energy:.6}");
         }
 
         compute_average_val(&mut values, 2, number_of_steps as u64);
@@ -1432,7 +1432,7 @@ mod tests {
                 // How to handle errors - we are returning a result or a string
                 Ok(atoms) => atoms,
                 Err(e) => {
-                    eprintln!("Failed to create atoms: {}", e); //Log the error
+                    error!("Failed to create atoms: {e}");
                     return; // Exit early or handle the error as needed
                 }
             };
@@ -1447,7 +1447,7 @@ mod tests {
         //let dof = 3 * new_simulation_md.len();
         // compute the final temperature of the system
         let t = lennard_jones_simulations::compute_temperature(&mut new_simulation_md, dof);
-        println!("Temperature is {}, and target is {}", t, t0);
+        info!("Final temperature={t:.3}, target={t0:.3}");
         assert!((t - t0).abs() < 5.0, "Temperature should approach target");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,13 @@ Such systems include electrons in atoms, molecules, and condensed matter. Proton
 and neutrons in nuclei, and nuclear matter.
 */
 
+use log::error;
 use sang_md::lennard_jones_simulations; // this is in lib
 use sang_md::molecule::molecule; // this is not in lib - this is the molecule module
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     // main code for running molecular dynamics simulations - version 2
     // create a new system
     let mut new_simulation_md =
@@ -30,7 +33,7 @@ fn main() {
             // How to handle errors - we are returning a result or a string
             Ok(atoms) => atoms,
             Err(e) => {
-                eprintln!("Failed to create atoms: {}", e); // Log the error
+                error!("Failed to create atoms: {e}");
                 return; // Exit early or handle the error as needed
             }
         };

--- a/src/minimization.rs
+++ b/src/minimization.rs
@@ -40,11 +40,11 @@ pub fn minimize_steepest_descent_particles(
             }
         }
 
-        println!("iter {iter:4}   max |F| = {max_f:.6}");
+        log::info!("Minimization iter {iter:>4} | max |F| = {max_f:.6}");
 
         // 3) check convergence
         if max_f < force_tol {
-            println!("Converged: max |F| = {max_f:.6} < {force_tol}");
+            log::info!("Converged | max |F| = {max_f:.6} < {force_tol}");
             break;
         }
 

--- a/src/molecule/molecule.rs
+++ b/src/molecule/molecule.rs
@@ -83,7 +83,6 @@ pub struct System {
     pub bonds: Vec<Bond>,
 }
 
-
 // System is all the atoms (global), bonded terms in global indices, and exclusion sets
 
 pub fn compute_bond_force(atoms: &mut Vec<Particle>, bond: &Bond, box_length: f64) -> f64 {

--- a/src/quantum/quantum_chem.rs
+++ b/src/quantum/quantum_chem.rs
@@ -398,9 +398,8 @@ pub mod self_consistent_field {
                     + (4. * f64::powi(self.I_1222 * c_1 * c_2, 3))
                     + f64::powi(self.I_2222 * c_2, 4);
 
-                println!(
-                    "The total energy is {} for iter {} and c_1 and c_2 values are {} {}",
-                    total_energy, entry, c_1, c_2
+                log::info!(
+                    "SCF iter {entry:>4} | E_total={total_energy:.8} c1={c_1:.6} c2={c_2:.6}"
                 );
 
                 // Computing the fock matrix 1,1 th element?

--- a/src/stat_mech/jarzynski.rs
+++ b/src/stat_mech/jarzynski.rs
@@ -40,6 +40,6 @@ mod tests {
         let beta = 1.0; // Inverse temperature (1/kT)
         let delta_f = jarzynski.calculate_free_energy_difference(beta);
 
-        println!("Free energy difference: {}", delta_f);
+        log::info!("Free energy difference: {delta_f:.6}");
     }
 }

--- a/src/thermostat_barostat/nose_hoover.rs
+++ b/src/thermostat_barostat/nose_hoover.rs
@@ -1,7 +1,6 @@
 pub mod nose_hoover {
     use crate::lennard_jones_simulations::{
-        compute_pressure_particles, compute_temperature_particles,
-        Particle,
+        compute_pressure_particles, compute_temperature_particles, Particle,
     };
 
     pub fn apply_thermostat_nose_hoover_particles(


### PR DESCRIPTION
### Motivation
- Replace scattered `println!`/`eprintln!` calls with structured logging so runtime output is leveled, configurable, and less noisy. 
- Provide clearer, consistent messages for energy/thermostat/SCF/minimization diagnostics to make logs easier to parse in normal runs and CI. 

### Description
- Add `env_logger` to `Cargo.toml` and initialize it in `main` with a default `info` filter via `env_logger::Builder::from_env(...).init()`. 
- Introduce `log` usage and imports (`info`, `debug`, `error`, `warn`) and replace `println!`/`eprintln!` with appropriate log macros across the codebase (notably `src/lib.rs`, `src/error.rs`, `src/main.rs`, `src/minimization.rs`, `src/quantum/quantum_chem.rs`, and `src/stat_mech/jarzynski.rs`). 
- Demote very verbose traces (velocity assignment and pairwise force updates) to `debug!` while promoting lifecycle and summary messages (init energy, per-step energy, thermostat and SCF progress, block averages, minimization/finish messages) to `info!` and warnings to `warn!`. 
- Small whitespace/import reorders to satisfy formatting and avoid unused-import lints. 

### Testing
- Ran `cargo fmt` to format the repository, which completed successfully. 
- Ran `cargo test`, which failed to fetch crates due to an environment network restriction (failed to download crates index: CONNECT tunnel 403), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1187b100832ebe1c59700e34c009)