### PR TITLE
Add optional MPI feature and MPI-enabled NVE integrator for parallel MD examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ env_logger = "0.11"
 assert-type-eq = "0.1.0"
 parameterized = "2.1.0"
 xdrfile = "0.3.0"
+mpi = { version = "0.8", optional = true }
+
+[features]
+default = []
+mpi = ["dep:mpi"]
 
 [profile.release]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -47,3 +47,16 @@ You’ll need a stable Rust toolchain:
 
 ```bash
 rustup update
+
+
+## ⚡ MPI Parallel NVE Example
+
+An MPI-enabled NVE integration path is available behind the `mpi` feature flag.
+It parallelizes Lennard-Jones force/energy accumulation across ranks and uses collective reductions to build global forces.
+
+```bash
+cargo run --features mpi
+mpirun -n 4 cargo run --features mpi
+```
+
+The MPI code path is intended as a parallel-programming example (`run_md_nve_mpi` / `run_md_nve_particles_mpi`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,10 @@ pub mod lennard_jones_simulations {
     use error::compute_average_val;
 
     use log::{debug, info};
+    #[cfg(feature = "mpi")]
+    use mpi::collective::SystemOperation;
+    #[cfg(feature = "mpi")]
+    use mpi::traits::*;
     use nalgebra::{zero, Vector3};
     use rand::Rng;
     use rand_distr::{Distribution, Normal};
@@ -1309,6 +1313,214 @@ pub mod lennard_jones_simulations {
         compute_average_val(&mut values, 2, number_of_steps as u64);
     }
 
+    #[cfg(feature = "mpi")]
+    fn rank_bounds(len: usize, rank: i32, size: i32) -> (usize, usize) {
+        let rank = rank as usize;
+        let size = size as usize;
+        let base = len / size;
+        let rem = len % size;
+
+        let start = rank * base + rank.min(rem);
+        let count = base + usize::from(rank < rem);
+        (start, start + count)
+    }
+
+    #[cfg(feature = "mpi")]
+    fn sync_particle_positions_and_velocities<C>(particles: &mut [Particle], world: &C)
+    where
+        C: mpi::topology::Communicator,
+    {
+        let n = particles.len();
+        let mut packed = vec![0.0_f64; n * 6];
+
+        if world.rank() == 0 {
+            for (idx, particle) in particles.iter().enumerate() {
+                let offset = idx * 6;
+                packed[offset] = particle.position.x;
+                packed[offset + 1] = particle.position.y;
+                packed[offset + 2] = particle.position.z;
+                packed[offset + 3] = particle.velocity.x;
+                packed[offset + 4] = particle.velocity.y;
+                packed[offset + 5] = particle.velocity.z;
+            }
+        }
+
+        world.process_at_rank(0).broadcast_into(&mut packed[..]);
+
+        for (idx, particle) in particles.iter_mut().enumerate() {
+            let offset = idx * 6;
+            particle.position.x = packed[offset];
+            particle.position.y = packed[offset + 1];
+            particle.position.z = packed[offset + 2];
+            particle.velocity.x = packed[offset + 3];
+            particle.velocity.y = packed[offset + 4];
+            particle.velocity.z = packed[offset + 5];
+        }
+    }
+
+    #[cfg(feature = "mpi")]
+    pub fn compute_forces_particles_mpi<C>(
+        particles: &mut Vec<Particle>,
+        box_length: f64,
+        world: &C,
+    ) -> f64
+    where
+        C: mpi::topology::Communicator + mpi::traits::CommunicatorCollectives,
+    {
+        let n = particles.len();
+        let (start, end) = rank_bounds(n, world.rank(), world.size());
+
+        let mut local_forces = vec![0.0_f64; n * 3];
+        let mut global_forces = vec![0.0_f64; n * 3];
+        let mut local_potential = 0.0_f64;
+        let mut global_potential = 0.0_f64;
+
+        for i in start..end {
+            for j in (i + 1)..n {
+                let r_vec = particles[i].position - particles[j].position;
+                let r_mic = minimum_image_convention(r_vec, box_length);
+                let r = r_mic.norm();
+                if r <= 1e-12 {
+                    continue;
+                }
+
+                let si = particles[i].lj_parameters.sigma;
+                let ei = particles[i].lj_parameters.epsilon;
+                let sj = particles[j].lj_parameters.sigma;
+                let ej = particles[j].lj_parameters.epsilon;
+                let sigma = 0.5 * (si + sj);
+                let epsilon = (ei * ej).sqrt();
+
+                let f_mag = lennard_jones_force_scalar(r, sigma, epsilon);
+                let f_vec = (r_mic / r) * f_mag;
+
+                let ioff = 3 * i;
+                local_forces[ioff] -= f_vec.x;
+                local_forces[ioff + 1] -= f_vec.y;
+                local_forces[ioff + 2] -= f_vec.z;
+
+                let joff = 3 * j;
+                local_forces[joff] += f_vec.x;
+                local_forces[joff + 1] += f_vec.y;
+                local_forces[joff + 2] += f_vec.z;
+
+                local_potential += lennard_jones_potential(r, sigma, epsilon);
+            }
+        }
+
+        world.all_reduce_into(
+            &local_forces[..],
+            &mut global_forces[..],
+            SystemOperation::sum(),
+        );
+        world.all_reduce_into(
+            &local_potential,
+            &mut global_potential,
+            SystemOperation::sum(),
+        );
+
+        for (idx, particle) in particles.iter_mut().enumerate() {
+            let offset = 3 * idx;
+            particle.force = Vector3::new(
+                global_forces[offset],
+                global_forces[offset + 1],
+                global_forces[offset + 2],
+            );
+        }
+
+        global_potential
+    }
+
+    #[cfg(feature = "mpi")]
+    pub fn run_md_nve_particles_mpi<C>(
+        particles: &mut Vec<Particle>,
+        number_of_steps: i32,
+        dt: f64,
+        box_length: f64,
+        thermostat: &str,
+        world: &C,
+    ) where
+        C: mpi::topology::Communicator + mpi::traits::CommunicatorCollectives,
+    {
+        sync_particle_positions_and_velocities(particles, world);
+
+        let mut values: Vec<f32> = Vec::new();
+        let mut potential_energy = compute_forces_particles_mpi(particles, box_length, world);
+
+        let n = particles.len();
+        let (start, end) = rank_bounds(n, world.rank(), world.size());
+        let local_kinetic: f64 = particles[start..end]
+            .iter()
+            .map(|p| 0.5 * p.mass * p.velocity.norm_squared())
+            .sum();
+        let mut kinetic_energy = 0.0;
+        world.all_reduce_into(&local_kinetic, &mut kinetic_energy, SystemOperation::sum());
+        let mut total_energy = kinetic_energy + potential_energy;
+
+        if world.rank() == 0 {
+            info!(
+                "Init particle energy (MPI) | E_kin={kinetic_energy:.6} E_pot={potential_energy:.6} E_tot={total_energy:.6}"
+            );
+        }
+
+        let mut xi_nose_hoover = 0.0;
+
+        for _step in 0..number_of_steps {
+            let mut a_old: Vec<Vector3<f64>> = Vec::with_capacity(particles.len());
+            for p in particles.iter() {
+                a_old.push(p.force / p.mass);
+            }
+
+            for (atom, a_o) in particles.iter_mut().zip(a_old.iter()) {
+                atom.velocity += 0.5 * a_o * dt;
+            }
+
+            for atom in particles.iter_mut() {
+                atom.update_position_verlet(dt);
+            }
+
+            pbc_update(particles, box_length);
+            potential_energy = compute_forces_particles_mpi(particles, box_length, world);
+
+            for p in particles.iter_mut() {
+                let a_new = p.force / p.mass;
+                p.update_velocity_verlet(a_new, dt);
+            }
+
+            if thermostat == "berendsen" {
+                apply_thermostat_berendsen_particles(particles, 300.0, 0.1, dt);
+            } else if thermostat == "andersen" {
+                apply_andersen_collisions(particles, 300.0, 1.0, dt);
+            } else if thermostat == "nose_hoover" {
+                apply_thermostat_nose_hoover_particles(
+                    particles,
+                    300.0,
+                    10.0,
+                    dt,
+                    &mut xi_nose_hoover,
+                );
+            }
+
+            // Keep all ranks synchronized even when stochastic thermostats are used.
+            sync_particle_positions_and_velocities(particles, world);
+
+            let local_kinetic: f64 = particles[start..end]
+                .iter()
+                .map(|p| 0.5 * p.mass * p.velocity.norm_squared())
+                .sum();
+            world.all_reduce_into(&local_kinetic, &mut kinetic_energy, SystemOperation::sum());
+            total_energy = kinetic_energy + potential_energy;
+
+            if world.rank() == 0 {
+                values.push(total_energy as f32);
+            }
+        }
+
+        if world.rank() == 0 {
+            compute_average_val(&mut values, 2, number_of_steps as u64);
+        }
+    }
+
     /*
 
     Systems portion of the code
@@ -1453,6 +1665,39 @@ pub mod lennard_jones_simulations {
                 run_md_nve_particles(particles, number_of_steps, dt, box_length, thermostat);
             }
             InitOutput::Systems(systems) => {
+                run_md_nve_systems(systems, number_of_steps, dt, box_length, thermostat);
+            }
+        }
+    }
+
+    #[cfg(feature = "mpi")]
+    pub fn run_md_nve_mpi<C>(
+        state: &mut InitOutput,
+        number_of_steps: i32,
+        dt: f64,
+        box_length: f64,
+        thermostat: &str,
+        world: &C,
+    ) where
+        C: mpi::topology::Communicator + mpi::traits::CommunicatorCollectives,
+    {
+        match state {
+            InitOutput::Particles(particles) => {
+                run_md_nve_particles_mpi(
+                    particles,
+                    number_of_steps,
+                    dt,
+                    box_length,
+                    thermostat,
+                    world,
+                );
+            }
+            InitOutput::Systems(systems) => {
+                if world.rank() == 0 {
+                    info!(
+                        "MPI NVE currently supports particle systems; falling back to serial systems integration."
+                    );
+                }
                 run_md_nve_systems(systems, number_of_steps, dt, box_length, thermostat);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ and neutrons in nuclei, and nuclear matter.
 */
 
 use log::error;
+#[cfg(feature = "mpi")]
+use mpi::traits::*;
 use sang_md::lennard_jones_simulations; // this is in lib
 use sang_md::molecule::molecule; // this is not in lib - this is the molecule module
 
@@ -25,6 +27,11 @@ fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     // main code for running molecular dynamics simulations - version 2
+
+    #[cfg(feature = "mpi")]
+    let universe = mpi::initialize().expect("MPI initialization failed");
+    #[cfg(feature = "mpi")]
+    let world = universe.world();
     // create a new system
     let mut new_simulation_md =
         match lennard_jones_simulations::create_atoms_with_set_positions_and_velocities(
@@ -37,10 +44,34 @@ fn main() {
                 return; // Exit early or handle the error as needed
             }
         };
-    // running a berendsen thermostat simulation
-    lennard_jones_simulations::run_md_nve(&mut new_simulation_md, 30, 0.0005, 10.0, "berendsen");
-    // running a andersen thermostat simulation
-    lennard_jones_simulations::run_md_nve(&mut new_simulation_md, 30, 0.0005, 10.0, "andersen");
+    #[cfg(feature = "mpi")]
+    {
+        if world.rank() == 0 {
+            log::info!("Running MPI-enabled NVE example");
+        }
+        lennard_jones_simulations::run_md_nve_mpi(
+            &mut new_simulation_md,
+            30,
+            0.0005,
+            10.0,
+            "berendsen",
+            &world,
+        );
+    }
+
+    #[cfg(not(feature = "mpi"))]
+    {
+        // running a berendsen thermostat simulation
+        lennard_jones_simulations::run_md_nve(
+            &mut new_simulation_md,
+            30,
+            0.0005,
+            10.0,
+            "berendsen",
+        );
+        // running a andersen thermostat simulation
+        lennard_jones_simulations::run_md_nve(&mut new_simulation_md, 30, 0.0005, 10.0, "andersen");
+    }
 
     // --------------------------------------------------------------------------------------//
     // Create a h2 system
@@ -50,5 +81,20 @@ fn main() {
 
     lennard_jones_simulations::set_molecular_positions_and_velocities(&mut systems_vec, 300.0);
     // need to modify this - need to implement the create_atoms_with_set_positions_and_velocities to work with molecules here as well
-    lennard_jones_simulations::run_md_nve(&mut systems_vec, 30, 0.0005, 10.0, "none");
+    #[cfg(feature = "mpi")]
+    {
+        lennard_jones_simulations::run_md_nve_mpi(
+            &mut systems_vec,
+            30,
+            0.0005,
+            10.0,
+            "none",
+            &world,
+        );
+    }
+
+    #[cfg(not(feature = "mpi"))]
+    {
+        lennard_jones_simulations::run_md_nve(&mut systems_vec, 30, 0.0005, 10.0, "none");
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide an MPI-enabled execution path so the NVE integrator can be used as a parallel-programming example for distributed Lennard‑Jones MD.
- Parallelize force/energy accumulation across ranks to demonstrate simple domain partitioning and collective reductions while preserving existing serial behavior.
- Keep the MPI code optional and non-invasive so default builds remain unchanged when MPI is not requested.

### Description
- Add an optional `mpi` dependency and feature flag to `Cargo.toml` (`mpi = { version = "0.8", optional = true }`, `features.mpi = ["dep:mpi"]`).
- Implement MPI helpers and distributed routines in `src/lib.rs`: `rank_bounds`, `sync_particle_positions_and_velocities`, `compute_forces_particles_mpi`, `run_md_nve_particles_mpi`, and a dispatcher `run_md_nve_mpi` that falls back to serial systems integration when needed.
- Wire `src/main.rs` to initialize MPI when built with `--features mpi` and to call the MPI-aware NVE paths while preserving the non‑MPI code path behind `#[cfg(not(feature = "mpi"))]`.
- Document the MPI usage in `README.md` with short usage examples (`cargo run --features mpi` and `mpirun -n 4 cargo run --features mpi`).

### Testing
- Ran `cargo fmt`, which completed successfully.
- Attempted `cargo check` and `cargo test`, but both failed in this environment due to crates.io network/index access errors (download of dependencies blocked by CONNECT tunnel 403), so compilation and unit tests could not be validated here.
- The change set was committed locally after formatting and editing (files modified: `Cargo.toml`, `src/lib.rs`, `src/main.rs`, `README.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a2e017c8832e824b68e86029c6e5)