### PR TITLE
Fix runaway subcell allocation in create_subcells

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,16 +187,17 @@ pub mod cell_subdivision {
 
     impl SimulationBox {
         pub fn create_subcells(&self, n_cells: usize) -> Vec<MolecularCoordinates> {
-            let mut cells = Vec::with_capacity(n_cells * n_cells * n_cells); // create the cells
-            let n_cells = n_cells * n_cells * n_cells;
+            let n_cells_per_dim = n_cells;
+            let n_cells_total = n_cells_per_dim * n_cells_per_dim * n_cells_per_dim;
+            let mut cells = Vec::with_capacity(n_cells_total); // create the cells
 
-            let dx = self.x_dimension / n_cells as f64;
-            let dy = self.y_dimension / n_cells as f64;
-            let dz = self.z_dimension / n_cells as f64;
+            let dx = self.x_dimension / n_cells_per_dim as f64;
+            let dy = self.y_dimension / n_cells_per_dim as f64;
+            let dz = self.z_dimension / n_cells_per_dim as f64;
 
-            for ix in 0..n_cells {
-                for iy in 0..n_cells {
-                    for iz in 0..n_cells {
+            for ix in 0..n_cells_per_dim {
+                for iy in 0..n_cells_per_dim {
+                    for iz in 0..n_cells_per_dim {
                         // create the cells and push the coordinates (with the center implemented)
                         cells.push(MolecularCoordinates {
                             center: Vector3::new(
@@ -207,7 +208,7 @@ pub mod cell_subdivision {
                             half_length: Vector3::new(dx * 0.5, dy * 0.5, dz * 0.5),
                             index: Vector3::new(ix, iy, iz),
                             atom_index: Vec::new(),
-                            head: vec![None; n_cells],
+                            head: vec![None; n_cells_total],
                             next: Vec::new(), //
                         });
                     }


### PR DESCRIPTION
### Motivation
- Prevent a memory blow-up in subcell creation that could exhaust RAM and crash runs by ensuring the function creates the intended n^3 cells rather than an excessively large number.
- Preserve correct subcell geometry and indexing so downstream routines receive a properly sized cell grid.

### Description
- Introduced `n_cells_per_dim` and `n_cells_total` so the function treats the input as cells-per-dimension and computes the total cell count separately.
- Allocate `cells` with capacity `n_cells_total` and compute `dx`, `dy`, `dz` using `n_cells_per_dim` so spacing is correct.
- Iterate the three nested loops from `0..n_cells_per_dim` and set each cell's `head` vector to length `n_cells_total` to match the total cell count.

### Testing
- Ran `cargo run`, which successfully built and executed the program without triggering host OOM or crash during subcell creation.
- The run produced normal startup logs and energy step output; no crash was observed in this environment (note: unrelated runtime warnings and some NaN energy values appeared later in the log but the subcell allocation no longer causes a crash).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad765e210832e8e536c2ebbe740fd)