### PR TITLE
Add point-particle water-box simulation output in GRO/XTC for VMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +83,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "build-probe-mpi"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+dependencies = [
+ "pkg-config",
+ "shell-words",
+]
 
 [[package]]
 name = "bytemuck"
@@ -48,16 +137,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -90,6 +243,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +262,21 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -121,6 +295,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,10 +335,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e71f2233af239a915476da8ee21a57331d82b9880c78220451ece7cb5862d313"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libffi"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0498fe5655f857803e156523e644dcdcdc3b3c7edda42ea2afdae2e09b2db87b"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d4f1d4ce15091955144350b75db16a96d4a63728500122706fb4d29a26afbb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -171,6 +410,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mpi"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+dependencies = [
+ "build-probe-mpi",
+ "conv",
+ "libffi",
+ "mpi-sys",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "mpi-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+dependencies = [
+ "bindgen",
+ "build-probe-mpi",
+ "cc",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +466,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -247,6 +528,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "parameterized"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +566,27 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -353,6 +667,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,8 +721,10 @@ name = "sang_md"
 version = "0.1.2"
 dependencies = [
  "assert-type-eq",
- "itertools",
+ "env_logger",
+ "itertools 0.14.0",
  "log",
+ "mpi",
  "nalgebra",
  "parameterized",
  "rand",
@@ -385,18 +736,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -414,6 +775,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -435,6 +802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +816,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -456,6 +849,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"
@@ -474,6 +873,21 @@ checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -69,3 +69,24 @@ The MPI code path is intended as a parallel-programming example (`run_md_nve_mpi
 make run
 make run-mpi NP=4
 ```
+
+## 🧪 Point-particle water-box style trajectory output (GRO + XTC)
+
+This repository now includes a runnable example binary that creates a simple Lennard-Jones point-particle fluid and writes outputs that can be opened in VMD:
+
+```bash
+cargo run --bin water_box
+```
+
+Generated files:
+- `water_box.gro` (final frame structure)
+- `water_box.xtc` (trajectory)
+
+### Open in VMD
+1. `vmd water_box.gro`
+2. In the VMD GUI: **File → Load Data Into Molecule...**
+3. Select `water_box.xtc` and load.
+
+> Notes:
+> - This is a coarse-grained, point-particle fluid setup (water-like in mass/density intent, not explicit 3-site/4-site water geometry).
+> - Coordinates are written in GRO/XTC-compatible units (nm in files).

--- a/src/bin/water_box.rs
+++ b/src/bin/water_box.rs
@@ -1,0 +1,104 @@
+use sang_md::cell_subdivision::SimulationBox;
+use sang_md::lennard_jones_simulations;
+use sang_md::lennard_jones_simulations::{
+    compute_forces_particles, pbc_update, InitOutput, Particle,
+};
+use sang_md::molecule::io::{write_gro, write_xtc};
+
+fn snapshot(particles: &[Particle]) -> Vec<Particle> {
+    particles.to_vec()
+}
+
+fn main() -> Result<(), String> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // A simple point-particle "box of water" style LJ fluid
+    let n_particles = 256;
+    let temperature = 300.0;
+    let mass = 18.015;
+    let dt = 0.002;
+    let nsteps = 200;
+    let box_length = 60.0;
+
+    let mut state = lennard_jones_simulations::create_atoms_with_set_positions_and_velocities(
+        n_particles,
+        temperature,
+        mass,
+        5.0,
+        box_length,
+        false,
+    )?;
+
+    let particles = match &mut state {
+        InitOutput::Particles(particles) => particles,
+        InitOutput::Systems(_) => return Err("expected particle initialization".to_string()),
+    };
+
+    let simulation_box = SimulationBox {
+        x_dimension: box_length,
+        y_dimension: box_length,
+        z_dimension: box_length,
+    };
+
+    let mut subcells = simulation_box.create_subcells(10);
+    simulation_box.store_atoms_in_cells_particles(particles, &mut subcells, 10);
+    compute_forces_particles(particles, box_length, &mut subcells);
+
+    let mut frames: Vec<Vec<Particle>> = Vec::with_capacity(nsteps as usize + 1);
+    frames.push(snapshot(particles));
+
+    for step in 0..nsteps {
+        let a_old: Vec<_> = particles.iter().map(|p| p.force / p.mass).collect();
+
+        for (p, a) in particles.iter_mut().zip(a_old.iter()) {
+            p.velocity += 0.5 * a * dt;
+        }
+
+        for p in particles.iter_mut() {
+            p.position += p.velocity * dt;
+        }
+
+        pbc_update(particles, box_length);
+
+        simulation_box.store_atoms_in_cells_particles(particles, &mut subcells, 10);
+        compute_forces_particles(particles, box_length, &mut subcells);
+
+        for p in particles.iter_mut() {
+            let a_new = p.force / p.mass;
+            p.velocity += 0.5 * a_new * dt;
+        }
+
+        lennard_jones_simulations::apply_thermostat_berendsen_particles(
+            particles,
+            temperature,
+            0.1,
+            dt,
+        );
+
+        if step % 10 == 0 {
+            frames.push(snapshot(particles));
+        }
+    }
+
+    write_gro(
+        "water_box.gro",
+        particles,
+        nalgebra::Vector3::new(box_length, box_length, box_length),
+        "Water-like point-particle box",
+    )?;
+
+    write_xtc(
+        "water_box.xtc",
+        &frames,
+        nalgebra::Vector3::new(box_length, box_length, box_length),
+        dt as f32,
+    )?;
+
+    println!(
+        "Wrote water_box.gro and water_box.xtc for {} particles and {} frames",
+        particles.len(),
+        frames.len()
+    );
+
+    Ok(())
+}

--- a/src/molecule/io.rs
+++ b/src/molecule/io.rs
@@ -1,6 +1,7 @@
 use crate::lennard_jones_simulations::{LJParameters, Particle};
 use nalgebra::Vector3;
 use std::fs;
+use xdrfile::{Frame, Trajectory, XTCTrajectory};
 
 fn default_mass(atom_name: &str) -> f64 {
     let trimmed = atom_name.trim();
@@ -160,6 +161,98 @@ pub fn read_gro(path: &str) -> Result<(Vec<Particle>, Option<Vector3<f64>>), Str
     read_gro_from_str(&contents)
 }
 
+pub fn write_gro(
+    path: &str,
+    particles: &[Particle],
+    box_dims: Vector3<f64>,
+    title: &str,
+) -> Result<(), String> {
+    // GRO expects distances in nm while this codebase stores positions in Å-like units.
+    let mut output = String::new();
+    output.push_str(title);
+    output.push('\n');
+    output.push_str(&format!("{:>5}\n", particles.len()));
+
+    for (index, particle) in particles.iter().enumerate() {
+        output.push_str(&format!(
+            "{:>5}{:<5}{:>5}{:>5}{:>8.3}{:>8.3}{:>8.3}\n",
+            1,
+            "WAT",
+            "OW",
+            index + 1,
+            particle.position.x / 10.0,
+            particle.position.y / 10.0,
+            particle.position.z / 10.0,
+        ));
+    }
+
+    output.push_str(&format!(
+        "{:>10.5}{:>10.5}{:>10.5}\n",
+        box_dims.x / 10.0,
+        box_dims.y / 10.0,
+        box_dims.z / 10.0,
+    ));
+
+    fs::write(path, output).map_err(|e| format!("failed to write gro file at '{path}': {e}"))
+}
+
+pub fn write_xtc(
+    path: &str,
+    frames: &[Vec<Particle>],
+    box_dims: Vector3<f64>,
+    dt_ps: f32,
+) -> Result<(), String> {
+    if frames.is_empty() {
+        return Err("cannot write xtc with zero frames".to_string());
+    }
+
+    let natoms = frames[0].len();
+    if natoms == 0 {
+        return Err("cannot write xtc with zero atoms".to_string());
+    }
+
+    for (idx, frame) in frames.iter().enumerate() {
+        if frame.len() != natoms {
+            return Err(format!(
+                "xtc frame {idx} has {} atoms but expected {natoms}",
+                frame.len()
+            ));
+        }
+    }
+
+    let mut trajectory =
+        XTCTrajectory::open_write(path).map_err(|e| format!("failed to open xtc file: {e}"))?;
+
+    let box_nm = [
+        [box_dims.x as f32 / 10.0, 0.0, 0.0],
+        [0.0, box_dims.y as f32 / 10.0, 0.0],
+        [0.0, 0.0, box_dims.z as f32 / 10.0],
+    ];
+
+    for (step, frame_particles) in frames.iter().enumerate() {
+        let mut frame = Frame::with_len(natoms);
+        frame.step = step;
+        frame.time = step as f32 * dt_ps;
+        frame.box_vector = box_nm;
+
+        for (atom_idx, particle) in frame_particles.iter().enumerate() {
+            frame.coords[atom_idx] = [
+                particle.position.x as f32 / 10.0,
+                particle.position.y as f32 / 10.0,
+                particle.position.z as f32 / 10.0,
+            ];
+        }
+
+        trajectory
+            .write(&frame)
+            .map_err(|e| format!("failed to write xtc frame {step}: {e}"))?;
+    }
+
+    trajectory
+        .flush()
+        .map_err(|e| format!("failed to flush xtc trajectory: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,5 +285,36 @@ END\n";
 
         let box_dims = box_dims.expect("box dims should exist");
         assert!((box_dims.x - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn writes_gro_records() {
+        let particles = vec![particle_from_coordinates(
+            1,
+            "O",
+            Vector3::new(1.0, 2.0, 3.0),
+        )];
+
+        let path = std::env::temp_dir().join(format!(
+            "sang_md_test_{}_{}.gro",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+
+        write_gro(
+            path.to_str().expect("utf8 temp path"),
+            &particles,
+            Vector3::new(10.0, 10.0, 10.0),
+            "Test",
+        )
+        .expect("gro write should succeed");
+
+        let content = fs::read_to_string(&path).expect("gro file readable");
+        let _ = fs::remove_file(path);
+        assert!(content.contains("WAT"));
+        assert!(content.contains("0.100"));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a simple, VMD-compatible trajectory output path for the engine so users can visualize point-particle simulations (GRO + XTC). 
- Expose small, reusable I/O helpers for writing GRO/XTC frames from the internal `Particle` structures. 
- Ship a focused example binary to demonstrate producing a trajectory file that can be inspected in VMD.

### Description
- Add `write_gro(...)` and `write_xtc(...)` to `src/molecule/io.rs` to export particle snapshots, including unit conversion to GRO/XTC-compatible units (nm) and basic validation for frames and atom counts. 
- Implement a new runnable example binary `src/bin/water_box.rs` that runs a small Lennard-Jones point-particle box simulation (velocity-Verlet + PBC + Berendsen thermostat), collects snapshots, and writes `water_box.gro` and `water_box.xtc`. 
- Add a unit test `writes_gro_records` to validate the GRO writer behavior and update `README.md` with instructions to run the example and load the outputs in VMD. 
- Use the existing `xdrfile` crate to write XTC frames via `XTCTrajectory` and `Frame`.

### Testing
- Ran `cargo test --offline molecule::io::tests::` and the `molecule::io` unit tests (including the new `writes_gro_records`) passed. 
- Built and ran the example with `cargo run --offline --bin water_box` and confirmed `water_box.gro` and `water_box.xtc` were generated successfully. 
- Verified the produced `water_box.gro` header and file sizes as part of the validation run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadc21cdc4832e95eb375cebc9406a)