### PR TITLE
Add initial PyO3-based Python extension scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "sang_md"
 version = "0.1.2"
 edition = "2021"
 
+[lib]
+name = "sang_md"
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"          # optional but handy for configs
@@ -16,10 +20,12 @@ assert-type-eq = "0.1.0"
 parameterized = "2.1.0"
 xdrfile = "0.3.0"
 mpi = { version = "0.8", optional = true }
+pyo3 = { version = "0.22", optional = true, features = ["extension-module"] }
 
 [features]
 default = []
 mpi = ["dep:mpi"]
+python = ["dep:pyo3"]
 
 [profile.release]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -90,3 +90,32 @@ Generated files:
 > Notes:
 > - This is a coarse-grained, point-particle fluid setup (water-like in mass/density intent, not explicit 3-site/4-site water geometry).
 > - Coordinates are written in GRO/XTC-compatible units (nm in files).
+
+## 🐍 Python interface (buildable scaffold)
+
+A minimal Python extension interface is available behind the `python` feature.
+It exposes:
+
+- `PyMdEngine(sigma, epsilon)` class
+- `PyMdEngine.force_at_distance(r)`
+- `lj_force_scalar(r, sigma, epsilon)`
+- `python_api_version()`
+
+### Build with maturin
+
+```bash
+pip install maturin
+maturin develop --features python
+```
+
+Then in Python:
+
+```python
+import sang_md_py
+
+engine = sang_md_py.PyMdEngine(1.0, 1.0)
+print(engine.force_at_distance(1.2))
+print(sang_md_py.lj_force_scalar(1.2, 1.0, 1.0))
+```
+
+This is intended as a starting point you can expand with trajectory stepping, system builders, and observables.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,8 @@ extern crate assert_type_eq;
 pub mod error;
 pub mod molecule;
 pub mod parameters;
+#[cfg(feature = "python")]
+mod python;
 pub mod thermostat_barostat;
 
 use std::collections::HashSet;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,44 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+use crate::lennard_jones_force_scalar;
+
+/// High-level Python entry point for building custom MD workflows.
+#[pyclass]
+pub struct PyMdEngine {
+    #[pyo3(get, set)]
+    pub sigma: f64,
+    #[pyo3(get, set)]
+    pub epsilon: f64,
+}
+
+#[pymethods]
+impl PyMdEngine {
+    #[new]
+    pub fn new(sigma: f64, epsilon: f64) -> Self {
+        Self { sigma, epsilon }
+    }
+
+    /// Compute Lennard-Jones force magnitude for a given inter-particle distance.
+    pub fn force_at_distance(&self, r: f64) -> f64 {
+        lennard_jones_force_scalar(r, self.sigma, self.epsilon)
+    }
+}
+
+#[pyfunction]
+fn lj_force_scalar(r: f64, sigma: f64, epsilon: f64) -> f64 {
+    lennard_jones_force_scalar(r, sigma, epsilon)
+}
+
+#[pyfunction]
+fn python_api_version() -> &'static str {
+    "0.1"
+}
+
+#[pymodule]
+fn sang_md_py(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyMdEngine>()?;
+    module.add_function(wrap_pyfunction!(lj_force_scalar, module)?)?;
+    module.add_function(wrap_pyfunction!(python_api_version, module)?)?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, buildable Python interface so Python-based workflows and tooling can be built on top of the Rust MD core.
- Make the Python bindings opt-in and non-invasive so normal Rust builds are unchanged unless explicitly enabled via a feature.
- Expose a tiny, stable starting API (engine class + LJ utility) that is easy to expand with system construction and stepping.

### Description
- Update `Cargo.toml` to add a `[lib]` section with `crate-type = ["rlib","cdylib"]`, an optional `pyo3` dependency, and a `python` feature to opt into Python bindings.
- Add `src/python.rs` which provides a PyO3 module `sang_md_py` exposing `PyMdEngine` (with `sigma`, `epsilon` and `force_at_distance`), `lj_force_scalar(...)`, and `python_api_version()`.
- Wire the module into the crate behind `#[cfg(feature = "python")] mod python;` in `src/lib.rs` and document build/use instructions in `README.md` (example showing `maturin develop --features python`).

### Testing
- Ran `cargo fmt --all` and `cargo fmt --all --check`, both of which succeeded.
- Ran `cargo check` which failed in this environment due to crates.io index/network access errors (HTTP 403) and not due to code errors in the changes.
- No Python extension build was performed in this environment; building with `maturin develop --features python` should be used to validate the Python module in a network-enabled/local environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae8eef1c0832e9f79d22af2b492bc)