### PR TITLE
Add Martini force-field reader and converter for MD systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +268,15 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -408,6 +423,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -607,6 +631,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +820,7 @@ dependencies = [
  "mpi",
  "nalgebra",
  "parameterized",
+ "pyo3",
  "rand",
  "rand_distr",
  "serde",
@@ -819,6 +913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +949,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Implements Lennard-Jones (LJ) interactions, bonded forces, velocity-Verlet time 
 - pbc wrapping  
 - Configurable time-step, LJ parameters, masses, and box sizes  
 - PDB and GRO coordinate readers (`molecule::io::{read_pdb, read_gro}`)  
+- Martini `.itp` force-field reader + converter (`molecule::martini::MartiniForceField`)  
 
 ---
 

--- a/src/molecule/martini.rs
+++ b/src/molecule/martini.rs
@@ -1,0 +1,424 @@
+use crate::lennard_jones_simulations::{LJParameters, Particle};
+use crate::molecule::molecule::{Angle, Bond, Dihedral, System};
+use nalgebra::Vector3;
+use std::collections::HashMap;
+use std::fs;
+
+#[derive(Clone, Debug, Default)]
+pub struct MartiniAtomType {
+    pub name: String,
+    pub mass: f64,
+    pub charge: f64,
+    pub sigma: Option<f64>,
+    pub epsilon: Option<f64>,
+    pub c6: Option<f64>,
+    pub c12: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MartiniAtom {
+    pub index: usize,
+    pub type_name: String,
+    pub charge: f64,
+    pub mass: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MartiniBond {
+    pub atom1: usize,
+    pub atom2: usize,
+    pub length: f64,
+    pub force_constant: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct MartiniAngle {
+    pub atom1: usize,
+    pub atom2: usize,
+    pub atom3: usize,
+    pub theta0_deg: f64,
+    pub force_constant: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct MartiniDihedral {
+    pub atom1: usize,
+    pub atom2: usize,
+    pub atom3: usize,
+    pub atom4: usize,
+    pub phase_deg: f64,
+    pub force_constant: f64,
+    pub multiplicity: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MartiniForceField {
+    pub molecule_name: Option<String>,
+    pub atom_types: HashMap<String, MartiniAtomType>,
+    pub atoms: Vec<MartiniAtom>,
+    pub bonds: Vec<MartiniBond>,
+    pub angles: Vec<MartiniAngle>,
+    pub dihedrals: Vec<MartiniDihedral>,
+}
+
+impl MartiniForceField {
+    pub fn parse_str(contents: &str) -> Result<Self, String> {
+        let mut ff = MartiniForceField::default();
+        let mut section = String::new();
+
+        for (line_number, raw_line) in contents.lines().enumerate() {
+            let line = raw_line.split(';').next().unwrap_or("").trim();
+
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            if line.starts_with('[') && line.ends_with(']') {
+                section = line[1..line.len() - 1].trim().to_ascii_lowercase();
+                continue;
+            }
+
+            let tokens: Vec<&str> = line.split_whitespace().collect();
+            if tokens.is_empty() {
+                continue;
+            }
+
+            match section.as_str() {
+                "moleculetype" => {
+                    if ff.molecule_name.is_none() {
+                        ff.molecule_name = Some(tokens[0].to_string());
+                    }
+                }
+                "atomtypes" => {
+                    let atom_type = parse_atomtype(&tokens)
+                        .map_err(|e| format!("line {}: {e}", line_number + 1))?;
+                    ff.atom_types.insert(atom_type.name.clone(), atom_type);
+                }
+                "atoms" => {
+                    ff.atoms.push(
+                        parse_atom(&tokens)
+                            .map_err(|e| format!("line {}: {e}", line_number + 1))?,
+                    );
+                }
+                "bonds" => {
+                    ff.bonds.push(
+                        parse_bond(&tokens)
+                            .map_err(|e| format!("line {}: {e}", line_number + 1))?,
+                    );
+                }
+                "angles" => {
+                    ff.angles.push(
+                        parse_angle(&tokens)
+                            .map_err(|e| format!("line {}: {e}", line_number + 1))?,
+                    );
+                }
+                "dihedrals" => {
+                    ff.dihedrals.push(
+                        parse_dihedral(&tokens)
+                            .map_err(|e| format!("line {}: {e}", line_number + 1))?,
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        if ff.atoms.is_empty() {
+            return Err("martini input did not contain an [ atoms ] section".to_string());
+        }
+
+        Ok(ff)
+    }
+
+    pub fn read_itp(path: &str) -> Result<Self, String> {
+        let contents = fs::read_to_string(path)
+            .map_err(|e| format!("failed to read martini file at '{path}': {e}"))?;
+        Self::parse_str(&contents)
+    }
+
+    pub fn to_system(&self, coordinates: &[Vector3<f64>]) -> Result<System, String> {
+        if coordinates.len() != self.atoms.len() {
+            return Err(format!(
+                "coordinate count mismatch: got {}, expected {}",
+                coordinates.len(),
+                self.atoms.len()
+            ));
+        }
+
+        let mut particles = Vec::with_capacity(self.atoms.len());
+        for (idx, atom) in self.atoms.iter().enumerate() {
+            let atom_type = self
+                .atom_types
+                .get(&atom.type_name)
+                .ok_or_else(|| format!("missing atom type '{}'", atom.type_name))?;
+
+            let (sigma, epsilon) = infer_lj_parameters(atom_type)?;
+            let mass = atom.mass.unwrap_or(atom_type.mass);
+
+            particles.push(Particle {
+                id: atom.index,
+                position: coordinates[idx],
+                velocity: Vector3::zeros(),
+                force: Vector3::zeros(),
+                lj_parameters: LJParameters {
+                    epsilon,
+                    sigma,
+                    number_of_atoms: 1,
+                },
+                mass,
+                energy: 0.0,
+                atom_type: idx as f64,
+                charge: atom.charge,
+            });
+        }
+
+        let bonds = self
+            .bonds
+            .iter()
+            .map(|b| Bond {
+                atom1: b.atom1 - 1,
+                atom2: b.atom2 - 1,
+                k: b.force_constant,
+                r0: b.length,
+            })
+            .collect();
+
+        let angles = self
+            .angles
+            .iter()
+            .map(|a| Angle {
+                atom1: a.atom1 - 1,
+                atom2: a.atom2 - 1,
+                atom3: a.atom3 - 1,
+                k: a.force_constant,
+                theta0: a.theta0_deg.to_radians(),
+            })
+            .collect();
+
+        let dihedrals = self
+            .dihedrals
+            .iter()
+            .map(|d| Dihedral {
+                atom1: d.atom1 - 1,
+                atom2: d.atom2 - 1,
+                atom3: d.atom3 - 1,
+                atom4: d.atom4 - 1,
+                k: d.force_constant,
+                multiplicity: d.multiplicity,
+                phase: d.phase_deg.to_radians(),
+            })
+            .collect();
+
+        Ok(System {
+            atoms: particles,
+            bonds,
+            angles,
+            dihedrals,
+            impropers: Vec::new(),
+        })
+    }
+}
+
+fn parse_atomtype(tokens: &[&str]) -> Result<MartiniAtomType, String> {
+    if tokens.len() < 5 {
+        return Err("atomtypes row requires at least 5 columns".to_string());
+    }
+
+    let name = tokens[0].to_string();
+    let mass = parse_f64(tokens, 1, "atomtype mass")?;
+    let charge = parse_f64(tokens, 2, "atomtype charge")?;
+
+    // Martini files can encode either sigma/epsilon or C6/C12 in the last 2 columns.
+    let maybe_a = tokens
+        .get(tokens.len().saturating_sub(2))
+        .ok_or_else(|| "atomtype missing nonbonded columns".to_string())?
+        .parse::<f64>()
+        .map_err(|e| format!("invalid atomtype nonbonded value: {e}"))?;
+
+    let maybe_b = tokens
+        .get(tokens.len().saturating_sub(1))
+        .ok_or_else(|| "atomtype missing nonbonded columns".to_string())?
+        .parse::<f64>()
+        .map_err(|e| format!("invalid atomtype nonbonded value: {e}"))?;
+
+    // Heuristic: sigma is usually ~0.3-0.8 nm, epsilon few kJ/mol; C12 is tiny.
+    let (sigma, epsilon, c6, c12) = if maybe_a > 0.0 && maybe_a < 2.0 && maybe_b < 20.0 {
+        (Some(maybe_a), Some(maybe_b), None, None)
+    } else {
+        (None, None, Some(maybe_a), Some(maybe_b))
+    };
+
+    Ok(MartiniAtomType {
+        name,
+        mass,
+        charge,
+        sigma,
+        epsilon,
+        c6,
+        c12,
+    })
+}
+
+fn parse_atom(tokens: &[&str]) -> Result<MartiniAtom, String> {
+    if tokens.len() < 7 {
+        return Err("atoms row requires at least 7 columns".to_string());
+    }
+
+    let index = parse_usize(tokens, 0, "atom index")?;
+    let type_name = tokens[1].to_string();
+    let charge = parse_f64(tokens, 6, "atom charge")?;
+    let mass = if tokens.len() > 7 {
+        Some(parse_f64(tokens, 7, "atom mass")?)
+    } else {
+        None
+    };
+
+    Ok(MartiniAtom {
+        index,
+        type_name,
+        charge,
+        mass,
+    })
+}
+
+fn parse_bond(tokens: &[&str]) -> Result<MartiniBond, String> {
+    if tokens.len() < 5 {
+        return Err("bonds row requires at least 5 columns".to_string());
+    }
+
+    Ok(MartiniBond {
+        atom1: parse_usize(tokens, 0, "bond atom1")?,
+        atom2: parse_usize(tokens, 1, "bond atom2")?,
+        length: parse_f64(tokens, 3, "bond length")?,
+        force_constant: parse_f64(tokens, 4, "bond force constant")?,
+    })
+}
+
+fn parse_angle(tokens: &[&str]) -> Result<MartiniAngle, String> {
+    if tokens.len() < 6 {
+        return Err("angles row requires at least 6 columns".to_string());
+    }
+
+    Ok(MartiniAngle {
+        atom1: parse_usize(tokens, 0, "angle atom1")?,
+        atom2: parse_usize(tokens, 1, "angle atom2")?,
+        atom3: parse_usize(tokens, 2, "angle atom3")?,
+        theta0_deg: parse_f64(tokens, 4, "angle theta0")?,
+        force_constant: parse_f64(tokens, 5, "angle force constant")?,
+    })
+}
+
+fn parse_dihedral(tokens: &[&str]) -> Result<MartiniDihedral, String> {
+    if tokens.len() < 8 {
+        return Err("dihedrals row requires at least 8 columns".to_string());
+    }
+
+    Ok(MartiniDihedral {
+        atom1: parse_usize(tokens, 0, "dihedral atom1")?,
+        atom2: parse_usize(tokens, 1, "dihedral atom2")?,
+        atom3: parse_usize(tokens, 2, "dihedral atom3")?,
+        atom4: parse_usize(tokens, 3, "dihedral atom4")?,
+        phase_deg: parse_f64(tokens, 5, "dihedral phase")?,
+        force_constant: parse_f64(tokens, 6, "dihedral force constant")?,
+        multiplicity: parse_usize(tokens, 7, "dihedral multiplicity")?,
+    })
+}
+
+fn infer_lj_parameters(atom_type: &MartiniAtomType) -> Result<(f64, f64), String> {
+    if let (Some(sigma), Some(epsilon)) = (atom_type.sigma, atom_type.epsilon) {
+        return Ok((sigma, epsilon));
+    }
+
+    if let (Some(c6), Some(c12)) = (atom_type.c6, atom_type.c12) {
+        if c6 <= 0.0 || c12 <= 0.0 {
+            return Err(format!(
+                "atom type '{}' has non-positive C6/C12",
+                atom_type.name
+            ));
+        }
+        let sigma = (c12 / c6).powf(1.0 / 6.0);
+        let epsilon = (c6 * c6) / (4.0 * c12);
+        return Ok((sigma, epsilon));
+    }
+
+    Err(format!(
+        "atom type '{}' is missing LJ parameters",
+        atom_type.name
+    ))
+}
+
+fn parse_f64(tokens: &[&str], index: usize, label: &str) -> Result<f64, String> {
+    tokens
+        .get(index)
+        .ok_or_else(|| format!("missing {label}"))?
+        .parse::<f64>()
+        .map_err(|e| format!("failed to parse {label}: {e}"))
+}
+
+fn parse_usize(tokens: &[&str], index: usize, label: &str) -> Result<usize, String> {
+    tokens
+        .get(index)
+        .ok_or_else(|| format!("missing {label}"))?
+        .parse::<usize>()
+        .map_err(|e| format!("failed to parse {label}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_martini_itp_and_builds_system() {
+        let itp = r#"
+[ moleculetype ]
+; name nrexcl
+WAT 1
+
+[ atomtypes ]
+;name mass charge ptype sigma epsilon
+P4   72.0 0.0 A 0.47 5.0
+
+[ atoms ]
+;nr type resnr residue atom cgnr charge mass
+1 P4 1 WAT W1 1 0.0 72.0
+2 P4 1 WAT W2 1 0.0 72.0
+
+[ bonds ]
+1 2 1 0.30 1250
+
+[ angles ]
+1 2 1 2 120.0 25.0
+
+[ dihedrals ]
+1 2 1 2 1 180.0 5.0 1
+"#;
+
+        let ff = MartiniForceField::parse_str(itp).expect("martini parsing should succeed");
+        assert_eq!(ff.atoms.len(), 2);
+        assert_eq!(ff.bonds.len(), 1);
+
+        let coords = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.3, 0.0, 0.0)];
+        let system = ff.to_system(&coords).expect("system build should succeed");
+
+        assert_eq!(system.atoms.len(), 2);
+        assert_eq!(system.bonds[0].atom1, 0);
+        assert!((system.atoms[0].lj_parameters.sigma - 0.47).abs() < 1e-12);
+        assert!((system.atoms[0].lj_parameters.epsilon - 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn parses_c6_c12_atomtypes() {
+        let itp = r#"
+[ atomtypes ]
+C1   72.0 0.0 A 2.0 1.0
+[ atoms ]
+1 C1 1 TST C1 1 0.0 72.0
+"#;
+
+        let ff = MartiniForceField::parse_str(itp).expect("martini parsing should succeed");
+        let atom_type = ff.atom_types.get("C1").expect("atomtype should exist");
+        let (sigma, epsilon) = infer_lj_parameters(atom_type).expect("lj inference should succeed");
+
+        assert!(sigma > 0.0);
+        assert!(epsilon > 0.0);
+    }
+}

--- a/src/molecule/mod.rs
+++ b/src/molecule/mod.rs
@@ -1,2 +1,3 @@
 pub mod io;
+pub mod martini;
 pub mod molecule;


### PR DESCRIPTION
### Motivation
- Provide a way to consume Martini / GROMACS-style `.itp` force-field definitions and convert them into the engine's internal `System`/`Particle` representation so the MD engine can run molecular systems defined in Martini topologies.  
- Support both common Martini nonbonded encodings (sigma/epsilon and C6/C12) so a wider set of topology files can be imported reliably.  

### Description
- Add a new module `src/molecule/martini.rs` implementing `MartiniForceField` with a parser for `.itp` sections (`[moleculetype]`, `[atomtypes]`, `[atoms]`, `[bonds]`, `[angles]`, `[dihedrals]`).  
- Implement `MartiniForceField::read_itp` and `MartiniForceField::to_system` to convert parsed topology and parameters into the engine `System` and `Particle` structs (including unit conversion for angles/dihedrals and bonded terms).  
- Implement LJ parameter inference that supports both `sigma/epsilon` and `C6/C12` atomtype encodings and returns clear errors for malformed inputs.  
- Export the module (`pub mod martini;` in `src/molecule/mod.rs`) and document the new reader in `README.md`; include unit tests covering parsing and conversion.  

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.  
- Ran targeted tests with `cargo test martini -- --nocapture` and the new martini unit tests passed (`parses_martini_itp_and_builds_system`, `parses_c6_c12_atomtypes`).  
- Executed the repository test runs (`cargo test`); the existing `molecule::io` and `molecule` tests executed successfully while one long-running thermostat test can exceed interactive timeouts in this environment, but the martini-related tests and the repository's molecular/IO tests passed in the runs performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf5052718832e8ad950fe8ed809f9)