### PR TITLE
Add umbrella-sampling free-energy API and chooser for Jarzynski/Umbrella methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Implements Lennard-Jones (LJ) interactions, bonded forces, velocity-Verlet time 
 - Configurable time-step, LJ parameters, masses, and box sizes  
 - PDB and GRO coordinate readers (`molecule::io::{read_pdb, read_gro}`)  
 - Martini `.itp` force-field reader + converter (`molecule::martini::MartiniForceField`)  
+- User-selectable free-energy API with separate Jarzynski and umbrella-sampling methods (`stat_mech_free_energy::jarzynski::choose_free_energy_method`)  
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod molecule;
 pub mod parameters;
 #[cfg(feature = "python")]
 mod python;
+pub mod stat_mech_free_energy;
 pub mod thermostat_barostat;
 
 use std::collections::HashSet;

--- a/src/stat_mech_free_energy/jarzynski.rs
+++ b/src/stat_mech_free_energy/jarzynski.rs
@@ -14,6 +14,13 @@ pub struct PullSample {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UmbrellaSample {
+    pub pull: PullSample,
+    pub umbrella_center: f64,
+    pub umbrella_k: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FreeEnergyEstimate {
     pub value: f64,
     pub stdev: f64,
@@ -44,6 +51,20 @@ pub enum JarzynskiError {
         line: usize,
     },
     EmptyWorkVector,
+    EmptyUmbrellaSamples,
+    InvalidTemperature(f64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FreeEnergyMethod {
+    Jarzynski,
+    UmbrellaSampling,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelectedFreeEnergyEstimate {
+    pub method: FreeEnergyMethod,
+    pub estimate: FreeEnergyEstimate,
 }
 
 pub fn read_pull_file(path: impl AsRef<Path>) -> Result<Vec<PullSample>, JarzynskiError> {
@@ -115,6 +136,7 @@ pub fn raw_jarzynski(
     if work.is_empty() {
         return Err(JarzynskiError::EmptyWorkVector);
     }
+    validate_temperature(temperature_k)?;
     let beta = 1.0 / (-BOLTZMANN_KCAL_MOL_K * temperature_k);
     let transformed: Vec<f64> = work.iter().map(|w| (w * beta).exp()).collect();
     let mean = transformed.iter().sum::<f64>() / transformed.len() as f64;
@@ -133,6 +155,7 @@ pub fn taylor_jarzynski(
     if work.is_empty() {
         return Err(JarzynskiError::EmptyWorkVector);
     }
+    validate_temperature(temperature_k)?;
     let beta = 1.0 / (-BOLTZMANN_KCAL_MOL_K * temperature_k);
     let mean_w = work.iter().sum::<f64>() / work.len() as f64;
     let mean_w2 = work.iter().map(|w| w * w).sum::<f64>() / work.len() as f64;
@@ -150,6 +173,7 @@ pub fn alpha_jarzynski(
     if work.is_empty() {
         return Err(JarzynskiError::EmptyWorkVector);
     }
+    validate_temperature(temperature_k)?;
     let beta = 1.0 / (-BOLTZMANN_KCAL_MOL_K * temperature_k);
     let mean_w = work.iter().sum::<f64>() / work.len() as f64;
     let stdev_w = stdev_population(work);
@@ -167,6 +191,83 @@ pub fn alpha_jarzynski(
         value,
         stdev: stdev_population(&shifted),
     })
+}
+
+pub fn umbrella_sampling_free_energy(
+    samples: &[UmbrellaSample],
+    temperature_k: f64,
+) -> Result<FreeEnergyEstimate, JarzynskiError> {
+    if samples.is_empty() {
+        return Err(JarzynskiError::EmptyUmbrellaSamples);
+    }
+    validate_temperature(temperature_k)?;
+    let beta = 1.0 / (BOLTZMANN_KCAL_MOL_K * temperature_k);
+
+    let unbiased_weights: Vec<f64> = samples
+        .iter()
+        .map(|sample| {
+            let ubias =
+                harmonic_bias_energy(sample.pull.z, sample.umbrella_center, sample.umbrella_k);
+            (beta * ubias).exp()
+        })
+        .collect();
+
+    let mean_weight = unbiased_weights.iter().sum::<f64>() / unbiased_weights.len() as f64;
+    let value = -mean_weight.ln() / beta;
+
+    Ok(FreeEnergyEstimate {
+        value,
+        stdev: stdev_population(&unbiased_weights),
+    })
+}
+
+pub fn choose_free_energy_method(
+    method: FreeEnergyMethod,
+    work: &[f64],
+    umbrella_samples: &[UmbrellaSample],
+    temperature_k: f64,
+) -> Result<SelectedFreeEnergyEstimate, JarzynskiError> {
+    let estimate = match method {
+        FreeEnergyMethod::Jarzynski => raw_jarzynski(work, temperature_k)?,
+        FreeEnergyMethod::UmbrellaSampling => {
+            umbrella_sampling_free_energy(umbrella_samples, temperature_k)?
+        }
+    };
+
+    Ok(SelectedFreeEnergyEstimate { method, estimate })
+}
+
+pub fn run_sample_free_energy_simulation(
+    method: FreeEnergyMethod,
+    temperature_k: f64,
+) -> Result<SelectedFreeEnergyEstimate, JarzynskiError> {
+    let sample_work = [0.9, 1.1, 1.0, 1.2];
+    let sample_umbrella = vec![
+        UmbrellaSample {
+            pull: PullSample {
+                index: 0,
+                z: -0.2,
+                bilayer_com: 0.0,
+                force: 0.0,
+                work: 0.9,
+            },
+            umbrella_center: -0.1,
+            umbrella_k: 5.0,
+        },
+        UmbrellaSample {
+            pull: PullSample {
+                index: 1,
+                z: 0.0,
+                bilayer_com: 0.0,
+                force: 0.0,
+                work: 1.1,
+            },
+            umbrella_center: 0.0,
+            umbrella_k: 5.0,
+        },
+    ];
+
+    choose_free_energy_method(method, &sample_work, &sample_umbrella, temperature_k)
 }
 
 pub fn compute_bins(
@@ -220,6 +321,17 @@ fn stdev_population(values: &[f64]) -> f64 {
     var.sqrt()
 }
 
+fn validate_temperature(temperature_k: f64) -> Result<(), JarzynskiError> {
+    if temperature_k <= 0.0 || !temperature_k.is_finite() {
+        return Err(JarzynskiError::InvalidTemperature(temperature_k));
+    }
+    Ok(())
+}
+
+fn harmonic_bias_energy(z: f64, center: f64, k: f64) -> f64 {
+    0.5 * k * (z - center).powi(2)
+}
+
 impl std::fmt::Display for JarzynskiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -234,6 +346,12 @@ impl std::fmt::Display for JarzynskiError {
                 write!(f, "invalid numeric value in `{path}` at line {line}")
             }
             JarzynskiError::EmptyWorkVector => write!(f, "no work values were provided"),
+            JarzynskiError::EmptyUmbrellaSamples => {
+                write!(f, "no umbrella samples were provided")
+            }
+            JarzynskiError::InvalidTemperature(t) => {
+                write!(f, "temperature must be finite and > 0 K, got {t}")
+            }
         }
     }
 }
@@ -242,12 +360,16 @@ impl std::error::Error for JarzynskiError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn parse_pull_file() {
-        let path = Path::new("../data/pull.1");
-        let samples = read_pull_file(path).expect("parse should succeed");
-        assert!(!samples.is_empty());
+        let mut path = std::env::temp_dir();
+        path.push("jarzynski_pull_test.dat");
+        fs::write(&path, "0 1.0 0.0 2.0 0.3\n1 1.2 0.0 2.1 0.4\n").unwrap();
+        let samples = read_pull_file(&path).expect("parse should succeed");
+        assert_eq!(samples.len(), 2);
+        let _ = fs::remove_file(path);
     }
 
     #[test]
@@ -258,5 +380,73 @@ mod tests {
         assert!(raw.value.is_finite());
         assert!(tay.value.is_finite());
         assert!((tay.stdev - stdev_population(&w)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn computes_umbrella_sampling_free_energy() {
+        let samples = vec![
+            UmbrellaSample {
+                pull: PullSample {
+                    index: 0,
+                    z: 0.0,
+                    bilayer_com: 0.0,
+                    force: 0.0,
+                    work: 0.9,
+                },
+                umbrella_center: 0.0,
+                umbrella_k: 5.0,
+            },
+            UmbrellaSample {
+                pull: PullSample {
+                    index: 1,
+                    z: 0.3,
+                    bilayer_com: 0.0,
+                    force: 0.0,
+                    work: 1.1,
+                },
+                umbrella_center: 0.2,
+                umbrella_k: 5.0,
+            },
+        ];
+
+        let estimate = umbrella_sampling_free_energy(&samples, 300.0).unwrap();
+        assert!(estimate.value.is_finite());
+        assert!(estimate.stdev.is_finite());
+    }
+
+    #[test]
+    fn chooser_uses_selected_method() {
+        let work = [1.0, 1.2, 1.4];
+        let umbrella = vec![UmbrellaSample {
+            pull: PullSample {
+                index: 0,
+                z: 0.0,
+                bilayer_com: 0.0,
+                force: 0.0,
+                work: 1.0,
+            },
+            umbrella_center: 0.0,
+            umbrella_k: 2.0,
+        }];
+
+        let jarzynski_choice =
+            choose_free_energy_method(FreeEnergyMethod::Jarzynski, &work, &umbrella, 300.0)
+                .unwrap();
+        assert_eq!(jarzynski_choice.method, FreeEnergyMethod::Jarzynski);
+
+        let umbrella_choice =
+            choose_free_energy_method(FreeEnergyMethod::UmbrellaSampling, &work, &umbrella, 300.0)
+                .unwrap();
+        assert_eq!(umbrella_choice.method, FreeEnergyMethod::UmbrellaSampling);
+    }
+
+    #[test]
+    fn sample_simulation_runs_for_both_methods() {
+        let jarz = run_sample_free_energy_simulation(FreeEnergyMethod::Jarzynski, 300.0).unwrap();
+        let umb =
+            run_sample_free_energy_simulation(FreeEnergyMethod::UmbrellaSampling, 300.0).unwrap();
+
+        assert!(jarz.estimate.value.is_finite());
+        assert!(umb.estimate.value.is_finite());
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a unified, user-selectable free-energy analysis API that supports both Jarzynski estimators and a simple umbrella-sampling reweighting pathway. 
- Improve robustness by validating temperatures and adding explicit error cases for empty umbrella inputs. 

### Description
- Export a new `stat_mech_free_energy` module from `lib.rs` and add a README entry advertising the user-selectable free-energy API via `stat_mech_free_energy::jarzynski::choose_free_energy_method`. 
- Implement `UmbrellaSample`, `FreeEnergyMethod`, and `SelectedFreeEnergyEstimate` types and extend `JarzynskiError` with `EmptyUmbrellaSamples` and `InvalidTemperature`. 
- Add `umbrella_sampling_free_energy`, `choose_free_energy_method`, and `run_sample_free_energy_simulation` functions plus helpers `validate_temperature` and `harmonic_bias_energy`, and integrate temperature validation into existing Jarzynski estimators. 

### Testing
- Unit tests added or updated in `stat_mech_free_energy::jarzynski` include `parse_pull_file`, `computes_estimators`, `computes_umbrella_sampling_free_energy`, `chooser_uses_selected_method`, and `sample_simulation_runs_for_both_methods`. 
- Tests were executed via the crate's unit test suite and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac99a22cc8832eb10d2d6d50ecdd62)