### PR TITLE
Add Monte Carlo simulation option alongside velocity Verlet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1315,6 +1315,83 @@ pub mod lennard_jones_simulations {
         compute_average_val(&mut values, 2, number_of_steps as u64);
     }
 
+    fn single_particle_energy(particles: &[Particle], idx: usize, box_length: f64) -> f64 {
+        let mut energy = 0.0;
+        let sigma_i = particles[idx].lj_parameters.sigma;
+        let epsilon_i = particles[idx].lj_parameters.epsilon;
+
+        for (j, other) in particles.iter().enumerate() {
+            if j == idx {
+                continue;
+            }
+
+            let sigma_j = other.lj_parameters.sigma;
+            let epsilon_j = other.lj_parameters.epsilon;
+            let sigma = (sigma_i + sigma_j) / 2.0;
+            let epsilon = (epsilon_i * epsilon_j).sqrt();
+            let r_vec = other.position - particles[idx].position;
+            let r = minimum_image_convention(r_vec, box_length).norm();
+            energy += lennard_jones_potential(r, sigma, epsilon);
+        }
+
+        energy
+    }
+
+    pub fn run_monte_carlo_particles(
+        particles: &mut Vec<Particle>,
+        number_of_steps: i32,
+        box_length: f64,
+        temperature: f64,
+    ) {
+        let mut values: Vec<f32> = Vec::new();
+        let mut rng = rand::rng();
+        let beta = 1.0 / temperature;
+        let max_displacement = 0.05 * box_length;
+        let mut accepted_moves: usize = 0;
+        let mut attempted_moves: usize = 0;
+
+        for _step in 0..number_of_steps {
+            for idx in 0..particles.len() {
+                let previous_position = particles[idx].position;
+                let previous_energy = single_particle_energy(particles, idx, box_length);
+
+                let displacement = Vector3::new(
+                    rng.random_range(-max_displacement..max_displacement),
+                    rng.random_range(-max_displacement..max_displacement),
+                    rng.random_range(-max_displacement..max_displacement),
+                );
+
+                particles[idx].position += displacement;
+                particles[idx].position.x = particles[idx].position.x.rem_euclid(box_length);
+                particles[idx].position.y = particles[idx].position.y.rem_euclid(box_length);
+                particles[idx].position.z = particles[idx].position.z.rem_euclid(box_length);
+
+                let trial_energy = single_particle_energy(particles, idx, box_length);
+                let delta_energy = trial_energy - previous_energy;
+                let metropolis = (-beta * delta_energy).exp();
+
+                let accepted = delta_energy <= 0.0 || rng.random::<f64>() < metropolis;
+                attempted_moves += 1;
+
+                if accepted {
+                    accepted_moves += 1;
+                } else {
+                    particles[idx].position = previous_position;
+                }
+            }
+
+            let potential_energy = site_site_energy_calculation(particles, box_length);
+            values.push(potential_energy as f32);
+        }
+
+        let acceptance = accepted_moves as f64 / attempted_moves.max(1) as f64;
+        info!(
+            "Monte Carlo complete | attempted={} accepted={} ratio={acceptance:.4}",
+            attempted_moves, accepted_moves
+        );
+        compute_average_val(&mut values, 2, number_of_steps as u64);
+    }
+
     #[cfg(feature = "mpi")]
     fn rank_bounds(len: usize, rank: i32, size: i32) -> (usize, usize) {
         let rank = rank as usize;
@@ -1662,8 +1739,24 @@ pub mod lennard_jones_simulations {
         box_length: f64,
         thermostat: &str,
     ) {
+        if thermostat == "monte_carlo" {
+            match state {
+                InitOutput::Particles(particles) => {
+                    run_monte_carlo_particles(particles, number_of_steps, box_length, 300.0);
+                }
+                InitOutput::Systems(_systems) => {
+                    info!(
+                        "Monte Carlo mode is currently supported for particle simulations only; using velocity Verlet for systems."
+                    );
+                }
+            }
+        }
+
         match state {
             InitOutput::Particles(particles) => {
+                if thermostat == "monte_carlo" {
+                    return;
+                }
                 run_md_nve_particles(particles, number_of_steps, dt, box_length, thermostat);
             }
             InitOutput::Systems(systems) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,28 @@ and neutrons in nuclei, and nuclear matter.
 use log::error;
 #[cfg(feature = "mpi")]
 use mpi::traits::*;
+use std::env;
 
 use sang_md::lennard_jones_simulations; // this is in lib
 use sang_md::molecule::molecule; // this is not in lib - this is the molecule module
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let integrator = env::args()
+        .find_map(|arg| arg.strip_prefix("--integrator=").map(str::to_owned))
+        .unwrap_or_else(|| "velocity_verlet".to_string());
+
+    let md_mode = match integrator.as_str() {
+        "velocity_verlet" => "berendsen",
+        "monte_carlo" => "monte_carlo",
+        other => {
+            log::warn!(
+                "Unknown integrator '{other}', falling back to velocity_verlet (Berendsen thermostat)."
+            );
+            "berendsen"
+        }
+    };
 
     // main code for running molecular dynamics simulations - version 2
 
@@ -47,30 +63,32 @@ fn main() {
     #[cfg(feature = "mpi")]
     {
         if world.rank() == 0 {
-            log::info!("Running MPI-enabled NVE example");
+            log::info!("Running MPI-enabled NVE example with integrator={integrator}");
         }
         lennard_jones_simulations::run_md_nve_mpi(
             &mut new_simulation_md,
             30,
             0.0005,
             10.0,
-            "berendsen",
+            md_mode,
             &world,
         );
     }
 
     #[cfg(not(feature = "mpi"))]
     {
-        // running a berendsen thermostat simulation
-        lennard_jones_simulations::run_md_nve(
-            &mut new_simulation_md,
-            30,
-            0.0005,
-            10.0,
-            "berendsen",
-        );
-        // running a andersen thermostat simulation
-        lennard_jones_simulations::run_md_nve(&mut new_simulation_md, 30, 0.0005, 10.0, "andersen");
+        // running either the default velocity-verlet simulation or monte-carlo simulation
+        lennard_jones_simulations::run_md_nve(&mut new_simulation_md, 30, 0.0005, 10.0, md_mode);
+        if md_mode != "monte_carlo" {
+            // running an andersen thermostat simulation after velocity-verlet demo
+            lennard_jones_simulations::run_md_nve(
+                &mut new_simulation_md,
+                30,
+                0.0005,
+                10.0,
+                "andersen",
+            );
+        }
     }
 
     // --------------------------------------------------------------------------------------//


### PR DESCRIPTION
### Motivation
- Provide an alternative integrator to the existing velocity-Verlet MD by adding a particle-based Metropolis Monte Carlo path so users can choose MC sampling when appropriate.
- Allow selecting the integrator at runtime via a simple CLI flag so example programs can exercise either algorithm without code edits.

### Description
- Added a per-particle trial-energy helper `single_particle_energy` used to compute the energy change for local MC moves. (`src/lib.rs`)
- Implemented a particle Monte Carlo routine `run_monte_carlo_particles` which proposes small random displacements with periodic wrapping and accepts/rejects via the Metropolis criterion, and records sampled potential energy values. (`src/lib.rs`)
- Extended `run_md_nve` to dispatch to the MC routine when `thermostat == "monte_carlo"` for `InitOutput::Particles`, while preserving existing behavior for molecular `Systems` and logging an informational message when MC is not supported. (`src/lib.rs`)
- Added CLI parsing in `main` to accept `--integrator=<velocity_verlet|monte_carlo>` and map that selection into the simulation flow; the non-MPI example skips the Andersen follow-up run when Monte Carlo is selected. (`src/main.rs`)
- Small logging messages and fallbacks were added to clarify integrator selection and unsupported cases.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `cargo check -q`, which completed successfully.
- Ran a targeted test invocation `cargo test -q run_md_nve_test -- --test-threads=1`, which completed (no filtered tests failed in the targeted run).
- A full `cargo test -q` was started in this environment but included a long-running test (`tests::berenden_pull_towards_target`) that exceeded the interactive run timeout, so targeted verification was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7d663fc4832e91be87738358fc8f)