### PR TITLE
Avoid double-applying bonded forces in energy-only path and disable systems demo in main

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,20 @@ pub mod lennard_jones_simulations {
         impropers: &[Improper],
         box_length: f64,
     ) -> f64 {
-        apply_all_bonded_forces_and_energy(atoms, bonds, angles, dihedrals, impropers, box_length)
+        // NOTE:
+        // `apply_all_bonded_forces_and_energy` updates forces as a side effect.
+        // During MD we call this helper for diagnostics only (energy reporting),
+        // so we must avoid mutating the active force buffers, otherwise bonded
+        // forces are effectively applied twice and the integrator can blow up.
+        let mut atoms_for_energy = atoms.clone();
+        apply_all_bonded_forces_and_energy(
+            &mut atoms_for_energy,
+            bonds,
+            angles,
+            dihedrals,
+            impropers,
+            box_length,
+        )
     }
 
     pub fn compute_intermolecular_forces_systems(systems: &mut [System], box_length: f64) -> f64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use mpi::traits::*;
 use std::env;
 
 use sang_md::lennard_jones_simulations; // this is in lib
-use sang_md::molecule::molecule; // this is not in lib - this is the molecule module
+// use sang_md::molecule::molecule; // systems demo intentionally disabled for now
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -102,27 +102,27 @@ fn main() {
     }
 
     // --------------------------------------------------------------------------------------//
+    // Systems run is intentionally commented out.
     // Create a h2 system
-    //  let h2 = molecule::make_h2_system();
-    //  let mut systems_vec = molecule::create_systems(&h2, 210);
-    //  // assign positions and velocities to the positions
+    // let h2 = molecule::make_h2_system();
+    // let mut systems_vec = molecule::create_systems(&h2, 210);
+    // // assign positions and velocities to the positions
+    // lennard_jones_simulations::set_molecular_positions_and_velocities(&mut systems_vec, 300.0);
+    // // need to modify this - need to implement the create_atoms_with_set_positions_and_velocities to work with molecules here as well
+    // #[cfg(feature = "mpi")]
+    // {
+    //     lennard_jones_simulations::run_md_nve_mpi(
+    //         &mut systems_vec,
+    //         30,
+    //         0.0005,
+    //         10.0,
+    //         "none",
+    //         &world,
+    //     );
+    // }
     //
-    //  lennard_jones_simulations::set_molecular_positions_and_velocities(&mut systems_vec, 300.0);
-    //  // need to modify this - need to implement the create_atoms_with_set_positions_and_velocities to work with molecules here as well
-    //  #[cfg(feature = "mpi")]
-    //  {
-    //      lennard_jones_simulations::run_md_nve_mpi(
-    //          &mut systems_vec,
-    //          30,
-    //          0.0005,
-    //          10.0,
-    //          "none",
-    //          &world,
-    //      );
-    //  }
-    //
-    //  #[cfg(not(feature = "mpi"))]
-    //  {
-    //      lennard_jones_simulations::run_md_nve(&mut systems_vec, 30, 0.0005, 10.0, "none", 3.0);
-    //  }
+    // #[cfg(not(feature = "mpi"))]
+    // {
+    //     lennard_jones_simulations::run_md_nve(&mut systems_vec, 30, 0.0005, 10.0, "none", 3.0);
+    // }
 }


### PR DESCRIPTION
### Motivation
- Prevent side-effect mutations from `apply_all_bonded_forces_and_energy` when used for diagnostics so that bonded forces are not applied twice and the integrator does not blow up.
- Temporarily disable the systems/molecule demo in `main.rs` because the `molecule` module integration is not ready and the example was causing confusion or misuse of non-library API.

### Description
- Change `compute_bonded_energy` to clone the `atoms` buffer and call `apply_all_bonded_forces_and_energy` on the clone so forces are not mutated on the active atoms during energy-only queries.
- Add an explanatory comment in `compute_bonded_energy` describing why the clone is necessary to avoid double application of forces.
- Comment out the `molecule` import and the systems demo run in `main.rs` and add a note that the systems run is intentionally disabled until molecule support is integrated.

### Testing
- Ran `cargo test` and the test suite completed successfully.
- Ran `cargo build` and a debug build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06c0e72fc832e958709261b1cb24a)