### PR TITLE
Avoid overlapping cloned molecules at initialization (fix unstable LJ energies)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,9 +443,18 @@ pub mod lennard_jones_simulations {
             }
             InitOutput::Systems(systems) => {
                 for sys in systems.iter_mut() {
+                    // Randomize each molecule position as a rigid translation so cloned
+                    // systems do not remain perfectly overlapped at initialization.
+                    let translation = Vector3::new(
+                        rng.random_range(0.0..10.0),
+                        rng.random_range(0.0..10.0),
+                        rng.random_range(0.0..10.0),
+                    );
+
                     // Each element is a System
                     // loop over each atom
                     for atom in sys.atoms.iter_mut() {
+                        atom.position += translation;
                         let sigma_mb = (temp / atom.mass).sqrt(); // 1.0 needs to be replaced with mass
                         let normal = Normal::new(0.0, sigma_mb).unwrap();
 

--- a/src/molecule/molecule.rs
+++ b/src/molecule/molecule.rs
@@ -412,8 +412,41 @@ pub fn create_systems(system: &System, number_of_molecules: i32) -> InitOutput {
      */
     let mut molecules: Vec<System> = Vec::new();
 
-    for _ in 0..number_of_molecules {
-        molecules.push(system.clone());
+    if number_of_molecules <= 0 {
+        return InitOutput::Systems(molecules);
+    }
+
+    // Build a simple cubic placement to avoid placing every molecule at the
+    // exact same coordinates (which causes extreme LJ overlaps/energies).
+    let mut min = Vector3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+    let mut max = Vector3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+    for atom in &system.atoms {
+        min.x = min.x.min(atom.position.x);
+        min.y = min.y.min(atom.position.y);
+        min.z = min.z.min(atom.position.z);
+        max.x = max.x.max(atom.position.x);
+        max.y = max.y.max(atom.position.y);
+        max.z = max.z.max(atom.position.z);
+    }
+
+    let span = max - min;
+    let base_spacing = span.x.max(span.y).max(span.z);
+    let spacing = (base_spacing + 2.5).max(3.0);
+    let n_side = (number_of_molecules as f64).cbrt().ceil() as i32;
+
+    for m in 0..number_of_molecules {
+        let ix = m % n_side;
+        let iy = (m / n_side) % n_side;
+        let iz = m / (n_side * n_side);
+
+        let mut sys_clone = system.clone();
+        let shift = Vector3::new(ix as f64 * spacing, iy as f64 * spacing, iz as f64 * spacing);
+
+        for atom in &mut sys_clone.atoms {
+            atom.position += shift;
+        }
+
+        molecules.push(sys_clone);
     }
 
     // output as the enum we want which will be a valid input to run_md_nve
@@ -437,6 +470,32 @@ mod tests {
             charge: -3.0,
         };
         assert_eq!(test_atom.id, 1);
+    }
+
+    #[test]
+    fn test_create_systems_offsets_molecules() {
+        let h2 = make_h2_system();
+        let created = create_systems(&h2, 8);
+
+        let systems = match created {
+            InitOutput::Systems(systems) => systems,
+            InitOutput::Particles(_) => panic!("expected systems output"),
+        };
+
+        assert_eq!(systems.len(), 8);
+
+        let first = systems[0].atoms[0].position;
+        let mut distinct_positions = 0;
+        for sys in systems.iter().skip(1) {
+            if (sys.atoms[0].position - first).norm() > 1e-12 {
+                distinct_positions += 1;
+            }
+        }
+
+        assert!(
+            distinct_positions > 0,
+            "cloned molecules should not all occupy the same coordinates"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Cloned `InitOutput::Systems` were placed at identical coordinates, producing severe Lennard–Jones overlaps and extreme energies during integration.
- The goal is to prevent those pathological overlaps so simulations start from reasonable configurations and avoid immediate blow-ups.

### Description
- Update `create_systems` (`src/molecule/molecule.rs`) to return early for non-positive counts and place clones on a simple cubic lattice with spacing derived from the molecule bounding box instead of exact coordinate duplication.
- Apply a rigid per-molecule random translation in `set_molecular_positions_and_velocities` (`src/lib.rs`) for `InitOutput::Systems` so cloned systems are offset before velocity sampling.
- Add regression test `test_create_systems_offsets_molecules` in `src/molecule/molecule.rs` to ensure cloned systems are not colocated.

### Testing
- Ran `cargo test -q test_create_systems_offsets_molecules`, which passed.
- Ran `cargo test -q molecule::tests::`, which passed all molecule-level tests.
- Ran full test suite with `cargo test -q`; the existing failing test `tests::berenden_pull_towards_target` remains failing and is unrelated to the systems-overlap fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b127da084c832ebeafaa711547095a)