### PR TITLE
ci: configure google release-please to create draft Rust releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+name: release-please
+
 on:
   push:
     branches:
@@ -7,18 +9,20 @@ permissions:
   contents: write
   pull-requests: write
 
-name: release-please
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Run Release Please
+        uses: googleapis/release-please-action@v4
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
-          release-type: simple
+          # Uses merged PR titles/commits (Conventional Commits) on main
+          # to continuously maintain a release PR.
+          release-type: rust
+
+          # Use the default GitHub token in Actions; no PAT required.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Create GitHub releases as drafts so maintainers can review and
+          # manually publish when ready.
+          draft: true


### PR DESCRIPTION
### Motivation
- Provide an automated, Google-supported release flow that accumulates merged PR changes into a release proposal on `main`.
- Allow maintainers to review the proposed version and publish on their schedule by creating releases as drafts.

### Description
- Updated the release workflow file at `.github/workflows/release-please.yml` to run `googleapis/release-please-action@v4` and set `release-type: rust` so Rust versioning rules are used.
- Switched authentication to the built-in `token: ${{ secrets.GITHUB_TOKEN }}` so no personal access token (PAT) is required.
- Enabled `draft: true` to create draft GitHub releases for manual review and publication.

### Testing
- Ran `git diff --check` which reported no issues and returned success.
- Attempted to parse the workflow with `python -c "import yaml; ..."` which failed because the `PyYAML` module is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e023c45c832e8fe468146f58a319)