### PR TITLE
Fix box-size handling in atom initialization (TIP3P box generator)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,7 +495,7 @@ pub mod lennard_jones_simulations {
         temp: f64,
         mass: f64,
         v_max: f64,
-        _box_dim_max: f64,
+        box_dim_max: f64,
         use_atom: bool,
     ) -> Result<InitOutput, String> {
         /*
@@ -507,6 +507,10 @@ pub mod lennard_jones_simulations {
         system for all the molecules
 
          */
+        if box_dim_max <= 0.0 {
+            return Err("box_dim_max must be > 0.0".to_string());
+        }
+
         let mut vector_positions: Vec<Particle> = Vec::new();
         let mut vector_system_positions: Vec<System> = Vec::new();
         let mut rng = rand::rng();
@@ -518,10 +522,10 @@ pub mod lennard_jones_simulations {
                 let mut particle = Particle {
                     // create position for the atom in question
                     position: Vector3::new(
-                        // generate x y z position values between -10 and 10
-                        rng.random_range(0.0..10.0), //TODO - need to add in box_length as a parameter
-                        rng.random_range(0.0..10.0), // ditto
-                        rng.random_range(0.0..10.0), // ditto
+                        // generate x y z position values using the configured box size
+                        rng.random_range(0.0..box_dim_max),
+                        rng.random_range(0.0..box_dim_max),
+                        rng.random_range(0.0..box_dim_max),
                     ),
 
                     // create velocity for atom in question


### PR DESCRIPTION
### Motivation
- The atom/system initializer used a hardcoded `0.0..10.0` coordinate range so generated boxes ignored the configured box size, which breaks box-based generators (e.g. TIP3P workflows).
- Validate box size input to avoid silent bad initializations when an invalid box dimension is passed.

### Description
- Use the provided `box_dim_max` parameter instead of the old hardcoded range by renaming `_box_dim_max` to `box_dim_max` and using it for coordinate generation in `create_atoms_with_set_positions_and_velocities` in `src/lib.rs`.
- Add an input validation `if box_dim_max <= 0.0 { return Err("box_dim_max must be > 0.0".to_string()); }` to fail fast on invalid box sizes.
- Replace `rng.random_range(0.0..10.0)` with `rng.random_range(0.0..box_dim_max)` so initial particle positions respect configured box dimensions.

### Testing
- Ran `cargo check -q`, which completed successfully.
- Ran `cargo test -q create_atoms_with_set_positions_and_velocities --lib`, which completed successfully (no failing tests for the targeted run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec74abe40832ebd4ecc736d541870)