### PR TITLE
Make TIP3P water box example runnable and accept TIP3P hydrogens with zero LJ terms

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -1,27 +1,14 @@
 use nalgebra::Vector3;
 use rand::Rng;
-use rand_distr::{Distribution, Normal};
-use sang_md::cell_subdivision::SimulationBox;
-use sang_md::lennard_jones_simulations::{
-    apply_thermostat_berendsen_particles, compute_forces_particles, compute_temperature_particles,
-    pbc_update, LJParameters, Particle,
-};
-use sang_md::molecule::io::{write_gro, write_xtc};
+use sang_md::lennard_jones_simulations::{self, InitOutput, Particle};
+use sang_md::molecule::io::write_gro;
 use sang_md::molecule::martini;
 use sang_md::molecule::molecule::System;
 
-fn create_tip3p_water_box(
-    n_side: usize,
-    box_length: f64,
-    temperature: f64,
-    n_particles: usize,
-) -> Result<Vec<System>, String> {
-    let spacing = box_length / n_side as f64; // spacing between molecules
+fn create_tip3p_water_box(n_side: usize, box_length: f64) -> Result<Vec<System>, String> {
+    let spacing = box_length / n_side as f64;
     let mut rng = rand::rng();
-    // create storage vector to store the
-    let mut systems = Vec::with_capacity(n_particles);
-
-    // Start modifying the molecule coordinates to be able to fit in the simulation box
+    let mut systems = Vec::with_capacity(n_side * n_side * n_side);
 
     let mut tip3p_forcefield_itp_instance =
         martini::ItpForceField::read_itp("ff/Charmm27.ff/charmm27.ff/tip3p.itp")?;
@@ -32,36 +19,24 @@ fn create_tip3p_water_box(
         .atom_types
         .extend(shared_atom_types);
 
-    // set up the initial oxygen and the h1/h2 positions
-    let mut o = Vector3::new(0.0, 0.0, 0.0); // oxygen position
-    let mut h1 = Vector3::new(0.9572, 0.0, 0.0); // h1 position
-    let mut h2 = Vector3::new(-0.23999, 0.92663, 0.0); // h2 position
-    let mut o_h1_h2_vec: [Vector3<f64>; 3] = [o, h1, h2];
-    // initiate the coordinates
-    //let mut tip3p_instance_initiated = tip3p_forcefield_itp_instance.to_system(o_h1_h2_vec);
+    let o = Vector3::new(0.0, 0.0, 0.0);
+    let h1 = Vector3::new(0.9572, 0.0, 0.0);
+    let h2 = Vector3::new(-0.23999, 0.92663, 0.0);
 
     for ix in 0..n_side {
         for iy in 0..n_side {
             for iz in 0..n_side {
                 let jitter = 0.05 * spacing;
-                // this will be the center cartesian point to seed the water molecule
                 let origin = Vector3::new(
                     (ix as f64 + 0.5) * spacing + rng.random_range(-jitter..jitter),
                     (iy as f64 + 0.5) * spacing + rng.random_range(-jitter..jitter),
                     (iz as f64 + 0.5) * spacing + rng.random_range(-jitter..jitter),
                 );
 
-                // copy an instance of the coordinate initiated tip3p molecule, modifying the position with the position coordinate above
-                let mut o_h1_h2_vec: [Vector3<f64>; 3] = [o + origin, h1 + origin, h2 + origin];
-
-                // initiate the coordinates
-                let mut tip3p_instance_initiated = tip3p_forcefield_itp_instance
-                    .to_system(&o_h1_h2_vec)
-                    .expect("the tip3p build should succeed");
-
-                // push the instance
+                let coordinates = [o + origin, h1 + origin, h2 + origin];
+                let tip3p_instance_initiated =
+                    tip3p_forcefield_itp_instance.to_system(&coordinates)?;
                 systems.push(tip3p_instance_initiated);
-                // generate the water molecule
             }
         }
     }
@@ -69,94 +44,50 @@ fn create_tip3p_water_box(
     Ok(systems)
 }
 
-fn snapshot(particles: &[Particle]) -> Vec<Particle> {
-    particles.to_vec()
+fn flatten_systems_to_particles(systems: &[System]) -> Vec<Particle> {
+    systems
+        .iter()
+        .flat_map(|system| system.atoms.iter().cloned())
+        .collect()
 }
 
-fn main() {
-    // Martini-style CG water-bead NVT setup (single-bead solvent model).
+fn main() -> Result<(), String> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let n_side = 6;
-    let target_temperature = 300.0;
-    let mass = 72.0;
-    let sigma = 0.47;
-    let epsilon = 0.2;
-    let box_length = 8.0;
-    let dt = 0.002;
-    let nsteps = 200;
-    let thermostat_tau = 0.05;
+    let box_length = 18.0;
+    let dt = 0.001;
+    let nsteps = 20;
 
-    let mut particles = create_tip3p_water_box(n_side, box_length, target_temperature, 100);
+    let mut systems = create_tip3p_water_box(n_side, box_length)?;
 
-    // Create the simulation box
-    let simulation_box = SimulationBox {
-        x_dimension: box_length,
-        y_dimension: box_length,
-        z_dimension: box_length,
-    };
+    let mut init_state = InitOutput::Systems(systems.clone());
+    lennard_jones_simulations::set_molecular_positions_and_velocities(&mut init_state, 300.0);
+    if let InitOutput::Systems(randomized) = init_state {
+        systems = randomized;
+    }
 
-    let mut subcells = simulation_box.create_subcells(10);
-    //simulation_box.store_atoms_in_cells_particles(&mut particles, &mut subcells, 10);
-    //compute_forces_particles(&mut particles, box_length, &mut subcells);
-    //
-    //let mut frames = Vec::with_capacity((nsteps / 20) as usize + 1);
-    //frames.push(snapshot(&particles));
-    //
-    //for step in 0..nsteps {
-    //    let a_old: Vec<_> = particles.iter().map(|p| p.force / p.mass).collect();
-    //
-    //    for (p, a) in particles.iter_mut().zip(a_old.iter()) {
-    //        p.velocity += 0.5 * a * dt;
-    //        p.position += p.velocity * dt;
-    //    }
-    //
-    //    pbc_update(&mut particles, box_length);
-    //
-    //    let mut subcells = simulation_box.create_subcells(10);
-    //    simulation_box.store_atoms_in_cells_particles(&mut particles, &mut subcells, 10);
-    //    compute_forces_particles(&mut particles, box_length, &mut subcells);
-    //
-    //    for p in &mut particles {
-    //        let a_new = p.force / p.mass;
-    //        p.velocity += 0.5 * a_new * dt;
-    //    }
-    //
-    //    apply_thermostat_berendsen_particles(
-    //        &mut particles,
-    //        target_temperature,
-    //        thermostat_tau,
-    //        dt,
-    //    );
-    //
-    //    if step % 100 == 0 {
-    //        let temp =
-    //            compute_temperature_particles(&particles, 3 * particles.len().saturating_sub(1));
-    //        log::info!("step={step:4} T={temp:.2}");
-    //    }
-    //
-    //    if step % 20 == 0 {
-    //        frames.push(snapshot(&particles));
-    //    }
-    //}
-    //
-    //write_gro(
-    //    "martini_water_box.gro",
-    //    &particles,
-    //    Vector3::new(box_length, box_length, box_length),
-    //    "Martini CG water box (NVT)",
-    //)?;
-    //
-    //write_xtc(
-    //    "martini_water_box.xtc",
-    //    &frames,
-    //    Vector3::new(box_length, box_length, box_length),
-    //    dt as f32,
-    //)?;
-    //
-    //println!(
-    //    "Wrote martini_water_box.gro and martini_water_box.xtc for {} particles and {} frames",
-    //    particles.len(),
-    //    frames.len()
-    //);
-    //
-    //Ok(())
+    lennard_jones_simulations::run_md_nve_systems(
+        &mut systems,
+        nsteps,
+        dt,
+        box_length,
+        "berendsen",
+    );
+
+    let particles = flatten_systems_to_particles(&systems);
+    write_gro(
+        "tip3p_water_box.gro",
+        &particles,
+        Vector3::new(box_length, box_length, box_length),
+        "TIP3P water box",
+    )?;
+
+    println!(
+        "Wrote tip3p_water_box.gro for {} molecules ({} atoms)",
+        systems.len(),
+        particles.len()
+    );
+
+    Ok(())
 }

--- a/src/molecule/martini.rs
+++ b/src/molecule/martini.rs
@@ -402,6 +402,10 @@ fn infer_lj_parameters(atom_type: &ItpAtomType) -> Result<(f64, f64), String> {
     }
 
     if let (Some(c6), Some(c12)) = (atom_type.c6, atom_type.c12) {
+        // Some force fields (e.g., TIP3P hydrogens) intentionally set both C6/C12 to zero.
+        if c6 == 0.0 && c12 == 0.0 {
+            return Ok((0.0, 0.0));
+        }
         if c6 <= 0.0 || c12 <= 0.0 {
             return Err(format!(
                 "atom type '{}' has non-positive C6/C12",


### PR DESCRIPTION
### Motivation
- Get the `tip3p_water_box` example working end-to-end so it can build a TIP3P molecular box and run systems MD.
- Avoid hard errors when reading CHARMM/TIP3P atom types that intentionally set `C6=0` and `C12=0` for hydrogen types (no LJ term).

### Description
- Rewrote `src/bin/tip3p_water_box.rs` into a runnable example that builds a TIP3P box from the CHARMM27 ITP, initializes molecular velocities via `set_molecular_positions_and_velocities`, runs a short systems MD using `run_md_nve_systems`, flattens systems to particles, and writes output with `write_gro`.
- Changed the `create_tip3p_water_box` signature and internals to produce `Vec<System>` instances placed on a lattice with jitter and to propagate errors instead of panicking.
- Updated `src/molecule/martini.rs::infer_lj_parameters` to special-case `c6 == 0.0 && c12 == 0.0` and return `(0.0, 0.0)` instead of treating this as a non-positive error, preserving behavior for intentionally non-LJ atom types (e.g., TIP3P hydrogens).
- Added short-run defaults and `env_logger` initialization in the example to keep example runtime reasonable and produce informative logs.

### Testing
- Ran `cargo check --bin tip3p_water_box`, which completed successfully.
- Ran `cargo run --bin tip3p_water_box`, which completed a short MD (reduced to `nsteps = 20`) and wrote `tip3p_water_box.gro` successfully (example log output and GRO write observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beef0e4a9c832ea1156d88f8ea4be2)