### PR TITLE
Preserve TIP3P molecular grouping in GRO export

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -1,7 +1,7 @@
 use nalgebra::Vector3;
 use rand::Rng;
-use sang_md::lennard_jones_simulations::{self, InitOutput, Particle};
-use sang_md::molecule::io::write_gro;
+use sang_md::lennard_jones_simulations::{self, InitOutput};
+use sang_md::molecule::io::write_gro_systems;
 use sang_md::molecule::martini;
 use sang_md::molecule::molecule::System;
 
@@ -44,13 +44,6 @@ fn create_tip3p_water_box(n_side: usize, box_length: f64) -> Result<Vec<System>,
     Ok(systems)
 }
 
-fn flatten_systems_to_particles(systems: &[System]) -> Vec<Particle> {
-    systems
-        .iter()
-        .flat_map(|system| system.atoms.iter().cloned())
-        .collect()
-}
-
 fn main() -> Result<(), String> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -75,18 +68,18 @@ fn main() -> Result<(), String> {
         "berendsen",
     );
 
-    let particles = flatten_systems_to_particles(&systems);
-    write_gro(
+    write_gro_systems(
         "tip3p_water_box.gro",
-        &particles,
+        &systems,
         Vector3::new(box_length, box_length, box_length),
         "TIP3P water box",
     )?;
 
+    let atom_count: usize = systems.iter().map(|system| system.atoms.len()).sum();
     println!(
         "Wrote tip3p_water_box.gro for {} molecules ({} atoms)",
         systems.len(),
-        particles.len()
+        atom_count
     );
 
     Ok(())

--- a/src/molecule/io.rs
+++ b/src/molecule/io.rs
@@ -1,4 +1,5 @@
 use crate::lennard_jones_simulations::{LJParameters, Particle};
+use crate::molecule::molecule::System;
 use nalgebra::Vector3;
 use std::fs;
 use xdrfile::{Frame, Trajectory, XTCTrajectory};
@@ -184,6 +185,54 @@ pub fn write_gro(
             particle.position.y / 10.0,
             particle.position.z / 10.0,
         ));
+    }
+
+    output.push_str(&format!(
+        "{:>10.5}{:>10.5}{:>10.5}\n",
+        box_dims.x / 10.0,
+        box_dims.y / 10.0,
+        box_dims.z / 10.0,
+    ));
+
+    fs::write(path, output).map_err(|e| format!("failed to write gro file at '{path}': {e}"))
+}
+
+pub fn write_gro_systems(
+    path: &str,
+    systems: &[System],
+    box_dims: Vector3<f64>,
+    title: &str,
+) -> Result<(), String> {
+    let natoms: usize = systems.iter().map(|system| system.atoms.len()).sum();
+
+    let mut output = String::new();
+    output.push_str(title);
+    output.push('\n');
+    output.push_str(&format!("{:>5}\n", natoms));
+
+    let mut atom_serial = 1usize;
+    for (res_index, system) in systems.iter().enumerate() {
+        for (atom_idx, atom) in system.atoms.iter().enumerate() {
+            let atom_name = match atom_idx {
+                0 => "OW",
+                1 => "HW1",
+                2 => "HW2",
+                _ => "X",
+            };
+
+            output.push_str(&format!(
+                "{:>5}{:<5}{:>5}{:>5}{:>8.3}{:>8.3}{:>8.3}\n",
+                (res_index + 1) % 100_000,
+                "WAT",
+                atom_name,
+                atom_serial % 100_000,
+                atom.position.x / 10.0,
+                atom.position.y / 10.0,
+                atom.position.z / 10.0,
+            ));
+
+            atom_serial += 1;
+        }
     }
 
     output.push_str(&format!(


### PR DESCRIPTION
### Motivation
- The previous pipeline flattened `System` objects to a single `Vec<Particle>` before writing GRO, which lost per-molecule residue grouping for TIP3P waters. 
- The intent is to preserve each TIP3P molecule (residue id and per-site names) in the GRO output so downstream tools see proper 3-site water geometry.

### Description
- Added `write_gro_systems` in `src/molecule/io.rs` to emit GRO files directly from `&[System]`, summing atom counts, preserving residue IDs, and assigning per-site atom names (`OW`, `HW1`, `HW2`).
- The new writer keeps the repository's unit conversion behavior (positions divided by `10.0` to produce nm) and uses a global atom serial that wraps mod `100_000` like GRO conventions.
- Updated `src/bin/tip3p_water_box.rs` to call `write_gro_systems` and removed the previous `flatten_systems_to_particles` flattening helper.
- The change preserves molecule grouping and readable residue/atom naming in the generated `tip3p_water_box.gro`.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo check --bin tip3p_water_box` which completed successfully.
- Ran `cargo run --bin tip3p_water_box` which executed end-to-end and produced `tip3p_water_box.gro` showing grouped TIP3P residues and per-site names (run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef7953174832e978d7259baed2201)