### PR TITLE
Add TIP3P pre-MD minimization step

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -44,6 +44,48 @@ fn create_tip3p_water_box(n_side: usize, box_length: f64) -> Result<Vec<System>,
     Ok(systems)
 }
 
+fn minimize_systems(
+    systems: &mut [System],
+    box_length: f64,
+    max_steps: usize,
+    step_size: f64,
+    force_tolerance: f64,
+) {
+    for step in 0..max_steps {
+        for sys in systems.iter_mut() {
+            lennard_jones_simulations::compute_bonded_forces_system(
+                &mut sys.atoms,
+                &sys.bonds,
+                box_length,
+            );
+        }
+        lennard_jones_simulations::compute_intermolecular_forces_systems(systems, box_length);
+
+        let mut max_force = 0.0;
+        for sys in systems.iter_mut() {
+            for atom in sys.atoms.iter_mut() {
+                let force_norm = atom.force.norm();
+                if force_norm > max_force {
+                    max_force = force_norm;
+                }
+                atom.position += (step_size / atom.mass) * atom.force;
+            }
+            lennard_jones_simulations::pbc_update(&mut sys.atoms, box_length);
+        }
+
+        if max_force < force_tolerance {
+            println!(
+                "Minimization converged in {} steps (max |F| = {:.6})",
+                step + 1,
+                max_force
+            );
+            return;
+        }
+    }
+
+    println!("Minimization reached max steps without full convergence (max_steps={max_steps})");
+}
+
 fn main() -> Result<(), String> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -51,8 +93,18 @@ fn main() -> Result<(), String> {
     let box_length = 18.0;
     let dt = 0.001;
     let nsteps = 20;
+    let minimization_steps = 200;
+    let minimization_step_size = 0.0005;
+    let minimization_force_tolerance = 1e-3;
 
     let mut systems = create_tip3p_water_box(n_side, box_length)?;
+    minimize_systems(
+        &mut systems,
+        box_length,
+        minimization_steps,
+        minimization_step_size,
+        minimization_force_tolerance,
+    );
 
     let mut init_state = InitOutput::Systems(systems.clone());
     lennard_jones_simulations::set_molecular_positions_and_velocities(&mut init_state, 300.0);


### PR DESCRIPTION
### Motivation
- Provide a simple pre-processing relaxation to remove large forces and reduce overlap after constructing the TIP3P water box so the subsequent MD integrator is more stable. 
- Keep the minimization lightweight and local to the `tip3p_water_box` binary so test/usage of the example is self-contained.

### Description
- Add a `minimize_systems` helper in `src/bin/tip3p_water_box.rs` that runs a force-based relaxation loop over systems and atoms. 
- Each minimization iteration calls `lennard_jones_simulations::compute_bonded_forces_system` and `lennard_jones_simulations::compute_intermolecular_forces_systems`, moves atoms by `(step_size / atom.mass) * atom.force`, and enforces periodic boundaries via `lennard_jones_simulations::pbc_update`.
- The minimizer computes the maximum force and exits early when `max_force < force_tolerance`, otherwise it runs up to `max_steps` and prints a summary on completion.
- Wire the minimizer into `main` with configurable parameters (`minimization_steps`, `minimization_step_size`, `minimization_force_tolerance`) and invoke it immediately after `create_tip3p_water_box` and before velocity initialization and `run_md_nve_systems`.

### Testing
- Ran `cargo fmt --all` to format the code and it completed successfully. 
- Ran `cargo check --bin tip3p_water_box` and the build completed successfully (with unrelated existing warnings in the library).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf3b0fc5ec832ea7dce21b70718fa1)