### PR TITLE
ITP preprocessor, full bonded & electrostatic forces, and initialization fixes

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -20,8 +20,8 @@ fn create_tip3p_water_box(n_side: usize, box_length: f64) -> Result<Vec<System>,
         .extend(shared_atom_types);
 
     let o = Vector3::new(0.0, 0.0, 0.0);
-    let h1 = Vector3::new(0.9572, 0.0, 0.0);
-    let h2 = Vector3::new(-0.23999, 0.92663, 0.0);
+    let h1 = Vector3::new(0.09572, 0.0, 0.0);
+    let h2 = Vector3::new(-0.023999, 0.092663, 0.0);
 
     for ix in 0..n_side {
         for iy in 0..n_side {
@@ -53,13 +53,11 @@ fn minimize_systems(
 ) {
     for step in 0..max_steps {
         for sys in systems.iter_mut() {
-            lennard_jones_simulations::compute_bonded_forces_system(
-                &mut sys.atoms,
-                &sys.bonds,
-                box_length,
-            );
+            lennard_jones_simulations::compute_all_bonded_forces_system(sys, box_length);
         }
         lennard_jones_simulations::compute_intermolecular_forces_systems(systems, box_length);
+        let _ =
+            lennard_jones_simulations::compute_electrostatic_forces_systems(systems, box_length);
 
         let mut max_force = 0.0;
         for sys in systems.iter_mut() {
@@ -107,7 +105,11 @@ fn main() -> Result<(), String> {
     );
 
     let mut init_state = InitOutput::Systems(systems.clone());
-    lennard_jones_simulations::set_molecular_positions_and_velocities(&mut init_state, 300.0);
+    lennard_jones_simulations::set_molecular_positions_and_velocities(
+        &mut init_state,
+        300.0,
+        box_length,
+    );
     if let InitOutput::Systems(randomized) = init_state {
         systems = randomized;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,11 @@ pub mod lennard_jones_simulations {
         total_energy
     }
 
-    pub fn set_molecular_positions_and_velocities(system_mol: &mut InitOutput, temp: f64) -> () {
+    pub fn set_molecular_positions_and_velocities(
+        system_mol: &mut InitOutput,
+        temp: f64,
+        box_length: f64,
+    ) -> () {
         let mut rng = rand::rng();
         // loop over each moleucle
 
@@ -469,9 +473,9 @@ pub mod lennard_jones_simulations {
                     // Randomize each molecule position as a rigid translation so cloned
                     // systems do not remain perfectly overlapped at initialization.
                     let translation = Vector3::new(
-                        rng.random_range(0.0..10.0),
-                        rng.random_range(0.0..10.0),
-                        rng.random_range(0.0..10.0),
+                        rng.random_range(0.0..box_length),
+                        rng.random_range(0.0..box_length),
+                        rng.random_range(0.0..box_length),
                     );
 
                     // Each element is a System
@@ -871,6 +875,25 @@ pub mod lennard_jones_simulations {
         apply_bonded_forces_and_energy(atoms, bonds, box_length)
     }
 
+    pub fn compute_all_bonded_forces_system(system: &mut System, box_length: f64) -> f64 {
+        for atom in system.atoms.iter_mut() {
+            atom.force = Vector3::zeros();
+        }
+        compute_bonded_forces(
+            &mut system.atoms,
+            &system.bonds,
+            &system.angles,
+            &system.dihedrals,
+            &system.impropers,
+            box_length,
+        )
+    }
+
+    pub fn compute_electrostatic_forces_systems(systems: &mut [System], box_length: f64) -> f64 {
+        let pme = PmeConfig::default();
+        add_electrostatic_forces_systems(systems, box_length, &pme)
+    }
+
     // -- temperature related computations
 
     pub fn kinetic_energy_particles(particles: &[Particle]) -> f64 {
@@ -881,11 +904,11 @@ pub mod lennard_jones_simulations {
     }
 
     pub fn compute_temperature_particles(particles: &[Particle], dof: usize) -> f64 {
-        // TODO - need to actually implement the boltzmann constant for computing the temperature
+        const KB_KJ_PER_MOL_K: f64 = 0.008_314_462_618_153_24;
         if dof == 0 {
             return 0.0;
         }
-        2.0 * kinetic_energy_particles(particles) / (dof as f64)
+        2.0 * kinetic_energy_particles(particles) / (KB_KJ_PER_MOL_K * dof as f64)
     }
 
     pub fn compute_temperature(state: &mut InitOutput, dof: usize) -> f64 {
@@ -913,7 +936,8 @@ pub mod lennard_jones_simulations {
             }
         };
 
-        2.0 * total_ke / (dof as f64)
+        const KB_KJ_PER_MOL_K: f64 = 0.008_314_462_618_153_24;
+        2.0 * total_ke / (KB_KJ_PER_MOL_K * dof as f64)
     }
 
     pub fn compute_pressure_particles(particles: &[Particle], box_length: f64) -> f64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,11 @@ fn main() {
     // now including electrostatics via the Ewald split in the MD engine.
     let h2 = molecule::make_h2_system();
     let mut systems_vec = molecule::create_systems(&h2, 12);
-    lennard_jones_simulations::set_molecular_positions_and_velocities(&mut systems_vec, 300.0);
+    lennard_jones_simulations::set_molecular_positions_and_velocities(
+        &mut systems_vec,
+        300.0,
+        10.0,
+    );
 
     #[cfg(feature = "mpi")]
     {

--- a/src/molecule/martini.rs
+++ b/src/molecule/martini.rs
@@ -1,7 +1,7 @@
 use crate::lennard_jones_simulations::{LJParameters, Particle};
 use crate::molecule::molecule::{Angle, Bond, Dihedral, System};
 use nalgebra::Vector3;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 
 #[derive(Clone, Debug, Default)]
@@ -65,13 +65,10 @@ impl ItpForceField {
     pub fn parse_str(contents: &str) -> Result<Self, String> {
         let mut ff = ItpForceField::default();
         let mut section = String::new();
+        let defines = default_preprocessor_defines();
 
-        for (line_number, raw_line) in contents.lines().enumerate() {
-            let line = raw_line.split(';').next().unwrap_or("").trim();
-
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
+        for (line_number, line) in preprocess_itp_lines(contents, &defines) {
+            let line = line.as_str();
 
             if line.starts_with('[') && line.ends_with(']') {
                 section = line[1..line.len() - 1].trim().to_ascii_lowercase();
@@ -144,13 +141,10 @@ impl ItpForceField {
     pub fn parse_atomtypes_str(contents: &str) -> Result<HashMap<String, ItpAtomType>, String> {
         let mut atom_types = HashMap::new();
         let mut section = String::new();
+        let defines = default_preprocessor_defines();
 
-        for (line_number, raw_line) in contents.lines().enumerate() {
-            let line = raw_line.split(';').next().unwrap_or("").trim();
-
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
+        for (line_number, line) in preprocess_itp_lines(contents, &defines) {
+            let line = line.as_str();
 
             if line.starts_with('[') && line.ends_with(']') {
                 section = line[1..line.len() - 1].trim().to_ascii_lowercase();
@@ -444,6 +438,83 @@ fn parse_usize(tokens: &[&str], index: usize, label: &str) -> Result<usize, Stri
         .ok_or_else(|| format!("missing {label}"))?
         .parse::<usize>()
         .map_err(|e| format!("failed to parse {label}: {e}"))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ConditionalFrame {
+    parent_active: bool,
+    condition_active: bool,
+    in_else_branch: bool,
+}
+
+fn default_preprocessor_defines() -> HashSet<&'static str> {
+    HashSet::from(["_FF_CHARMM", "FLEXIBLE", "CHARMM_TIP3P"])
+}
+
+fn is_active(stack: &[ConditionalFrame]) -> bool {
+    stack.last().map_or(true, |frame| {
+        if frame.in_else_branch {
+            frame.parent_active && !frame.condition_active
+        } else {
+            frame.parent_active && frame.condition_active
+        }
+    })
+}
+
+fn preprocess_itp_lines(contents: &str, defines: &HashSet<&'static str>) -> Vec<(usize, String)> {
+    let mut filtered = Vec::new();
+    let mut condition_stack: Vec<ConditionalFrame> = Vec::new();
+
+    for (line_number, raw_line) in contents.lines().enumerate() {
+        let line = raw_line.split(';').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(symbol) = line.strip_prefix("#ifdef").map(str::trim) {
+            let frame = ConditionalFrame {
+                parent_active: is_active(&condition_stack),
+                condition_active: defines.contains(symbol),
+                in_else_branch: false,
+            };
+            condition_stack.push(frame);
+            continue;
+        }
+
+        if let Some(symbol) = line.strip_prefix("#ifndef").map(str::trim) {
+            let frame = ConditionalFrame {
+                parent_active: is_active(&condition_stack),
+                condition_active: !defines.contains(symbol),
+                in_else_branch: false,
+            };
+            condition_stack.push(frame);
+            continue;
+        }
+
+        if line.starts_with("#else") {
+            if let Some(last) = condition_stack.last_mut() {
+                last.in_else_branch = true;
+            }
+            continue;
+        }
+
+        if line.starts_with("#endif") {
+            let _ = condition_stack.pop();
+            continue;
+        }
+
+        if line.starts_with('#') {
+            continue;
+        }
+
+        if !is_active(&condition_stack) {
+            continue;
+        }
+
+        filtered.push((line_number, line.to_string()));
+    }
+
+    filtered
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Allow reading CHARMM-style ITP files that contain preprocessor conditionals and shared defines. 
- Compute full intramolecular bonded forces (bonds/angles/dihedrals/impropers) and include electrostatic forces in minimization. 
- Ensure molecule randomization uses the simulation box and compute temperatures with the correct Boltzmann constant and initialize TIP3P geometry correctly.

### Description
- Add an ITP preprocessor: implement `preprocess_itp_lines`, `default_preprocessor_defines`, and `ConditionalFrame` and wire them into `ItpForceField::parse_str` and `parse_atomtypes_str` so `#ifdef/#ifndef/#else/#endif` blocks are respected during parsing. 
- Add `compute_all_bonded_forces_system` to compute bonded forces for bonds, angles, dihedrals, and impropers, and add `compute_electrostatic_forces_systems` which invokes PME using `PmeConfig::default()`; replace previous bonded-only call sites with the new functions. 
- Change `set_molecular_positions_and_velocities` signature to accept `box_length` and use it to randomize system translations; update all call sites (`main.rs`, `tip3p_water_box.rs`). 
- Correct temperature computations to use the Boltzmann constant (`KB_KJ_PER_MOL_K`) in `compute_temperature` and `compute_temperature_particles`. 
- Fix TIP3P hydrogen coordinates in `tip3p_water_box.rs` and call electrostatic force computation during minimization. 

### Testing
- Ran unit tests with `cargo test`, including `parses_martini_itp_and_builds_system`, and the test suite passed. 
- Performed a local build (`cargo build`) to ensure the changed APIs compile successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf41762920832e923b2b043be3aa58)