### PR TITLE
Add SHAKE/RATTLE constraints for TIP3P water integration

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -1,9 +1,10 @@
 use nalgebra::Vector3;
 use rand::Rng;
-use sang_md::lennard_jones_simulations::{self, InitOutput};
+use sang_md::lennard_jones_simulations::{self, ConstraintOptions, InitOutput};
 use sang_md::molecule::io::write_gro_systems;
 use sang_md::molecule::martini;
 use sang_md::molecule::molecule::System;
+use sang_md::molecule::shake_rattle::shake_rattle;
 
 fn create_tip3p_water_box(n_side: usize, box_length: f64) -> Result<Vec<System>, String> {
     let spacing = box_length / n_side as f64;
@@ -114,12 +115,23 @@ fn main() -> Result<(), String> {
         systems = randomized;
     }
 
-    lennard_jones_simulations::run_md_nve_systems(
+    let constraints_by_system: Result<Vec<_>, _> = systems
+        .iter()
+        .map(shake_rattle::tip3p_constraints_from_system)
+        .collect();
+    let constraint_options = ConstraintOptions {
+        constraints_by_system: constraints_by_system?,
+        tolerance: 1e-10,
+        max_iter: 100,
+    };
+
+    lennard_jones_simulations::run_md_nve_systems_with_constraints(
         &mut systems,
         nsteps,
         dt,
         box_length,
         "berendsen",
+        Some(&constraint_options),
     );
 
     write_gro_systems(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub mod lennard_jones_simulations {
     use crate::molecule::molecule::make_h2_system;
     use crate::molecule::molecule::Bond;
     use crate::molecule::molecule::System;
-    use crate::molecule::shake_rattle::shake_rattle;
+    use crate::molecule::shake_rattle::shake_rattle::{self, DistanceConstraint};
     use crate::molecule::molecule::{
         apply_all_bonded_forces_and_energy, apply_bonded_forces_and_energy, Angle, Dihedral,
         Improper,
@@ -367,6 +367,13 @@ pub mod lennard_jones_simulations {
     pub enum InitMode {
         Atoms,
         Molecules,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ConstraintOptions {
+        pub constraints_by_system: Vec<Vec<DistanceConstraint>>,
+        pub tolerance: f64,
+        pub max_iter: usize,
     }
 
     impl Particle {
@@ -1924,17 +1931,22 @@ pub mod lennard_jones_simulations {
         box_length: f64,
         thermostat: &str,
     ) {
+        run_md_nve_systems_with_constraints(systems, number_of_steps, dt, box_length, thermostat, None);
+    }
+
+    pub fn run_md_nve_systems_with_constraints(
+        systems: &mut Vec<System>,
+        number_of_steps: i32,
+        dt: f64,
+        box_length: f64,
+        thermostat: &str,
+        constraint_options: Option<&ConstraintOptions>,
+    ) {
         let mut values: Vec<f32> = Vec::new();
         let mut total_energy = 0.0;
         let mut kinetic_energy = 0.0;
         let mut potential_energy = 0.0;
         let pme = PmeConfig::default();
-        let shake_tolerance = 1e-10;
-        let shake_max_iter = 100;
-        let tip3p_constraint_sets: Vec<Option<Vec<(usize, usize, f64)>>> = systems
-            .iter()
-            .map(|system| shake_rattle::tip3p_constraints_from_system(system).ok())
-            .collect();
 
         // Create the subcells for the simulation box
         let simulation_box = cell_subdivision::SimulationBox {
@@ -1989,8 +2001,10 @@ pub mod lennard_jones_simulations {
                 }
 
                 pbc_update(&mut sys.atoms, box_length);
-                if let Some(constraints) = &tip3p_constraint_sets[s] {
-                    shake_rattle::apply_shake(sys, constraints, shake_tolerance, shake_max_iter);
+                if let Some(options) = constraint_options {
+                    if let Some(constraints) = options.constraints_by_system.get(s) {
+                        shake_rattle::apply_shake(sys, constraints, options.tolerance, options.max_iter);
+                    }
                 }
 
                 for a in sys.atoms.iter_mut() {
@@ -2014,8 +2028,10 @@ pub mod lennard_jones_simulations {
                     let a_new = a.force / a.mass;
                     a.update_velocity_verlet(a_new, dt);
                 }
-                if let Some(constraints) = &tip3p_constraint_sets[s] {
-                    shake_rattle::apply_rattle(sys, constraints, shake_tolerance, shake_max_iter);
+                if let Some(options) = constraint_options {
+                    if let Some(constraints) = options.constraints_by_system.get(s) {
+                        shake_rattle::apply_rattle(sys, constraints, options.tolerance, options.max_iter);
+                    }
                 }
 
                 let dof = 3 * sys.atoms.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,7 @@ pub mod lennard_jones_simulations {
     use crate::molecule::molecule::make_h2_system;
     use crate::molecule::molecule::Bond;
     use crate::molecule::molecule::System;
+    use crate::molecule::shake_rattle::shake_rattle;
     use crate::molecule::molecule::{
         apply_all_bonded_forces_and_energy, apply_bonded_forces_and_energy, Angle, Dihedral,
         Improper,
@@ -1928,6 +1929,12 @@ pub mod lennard_jones_simulations {
         let mut kinetic_energy = 0.0;
         let mut potential_energy = 0.0;
         let pme = PmeConfig::default();
+        let shake_tolerance = 1e-10;
+        let shake_max_iter = 100;
+        let tip3p_constraint_sets: Vec<Option<Vec<(usize, usize, f64)>>> = systems
+            .iter()
+            .map(|system| shake_rattle::tip3p_constraints_from_system(system).ok())
+            .collect();
 
         // Create the subcells for the simulation box
         let simulation_box = cell_subdivision::SimulationBox {
@@ -1966,7 +1973,7 @@ pub mod lennard_jones_simulations {
 
         // --- time integration loop ---
         for _step in 0..number_of_steps {
-            for sys in systems.iter_mut() {
+            for (s, sys) in systems.iter_mut().enumerate() {
                 let mut a_old: Vec<Vector3<f64>> = Vec::with_capacity(sys.atoms.len());
 
                 for a in sys.atoms.iter() {
@@ -1982,6 +1989,9 @@ pub mod lennard_jones_simulations {
                 }
 
                 pbc_update(&mut sys.atoms, box_length);
+                if let Some(constraints) = &tip3p_constraint_sets[s] {
+                    shake_rattle::apply_shake(sys, constraints, shake_tolerance, shake_max_iter);
+                }
 
                 for a in sys.atoms.iter_mut() {
                     a.force = Vector3::zeros();
@@ -2003,6 +2013,9 @@ pub mod lennard_jones_simulations {
                 for a in sys.atoms.iter_mut() {
                     let a_new = a.force / a.mass;
                     a.update_velocity_verlet(a_new, dt);
+                }
+                if let Some(constraints) = &tip3p_constraint_sets[s] {
+                    shake_rattle::apply_rattle(sys, constraints, shake_tolerance, shake_max_iter);
                 }
 
                 let dof = 3 * sys.atoms.len();

--- a/src/molecule/shake_rattle.rs
+++ b/src/molecule/shake_rattle.rs
@@ -10,16 +10,53 @@ pub mod shake_rattle {
 
     use crate::molecule::molecule::System;
 
-    pub fn tip3p_constraints_from_system(system: &System) -> Result<Vec<(usize, usize, f64)>, String> {
+    #[derive(Clone, Debug)]
+    pub struct DistanceConstraint {
+        pub index_i: usize,
+        pub index_j: usize,
+        pub target_distance: f64,
+    }
+
+    pub fn constraints_from_bonds(system: &System) -> Vec<DistanceConstraint> {
+        system
+            .bonds
+            .iter()
+            .map(|bond| DistanceConstraint {
+                index_i: bond.atom1,
+                index_j: bond.atom2,
+                target_distance: bond.r0,
+            })
+            .collect()
+    }
+
+    pub fn constraints_from_pairs(
+        system: &System,
+        pairs: &[(usize, usize)],
+    ) -> Result<Vec<DistanceConstraint>, String> {
+        let mut constraints = Vec::with_capacity(pairs.len());
+        for &(i, j) in pairs {
+            if i >= system.atoms.len() || j >= system.atoms.len() {
+                return Err(format!(
+                    "Constraint pair ({i}, {j}) is out of bounds for {} atoms.",
+                    system.atoms.len()
+                ));
+            }
+            constraints.push(DistanceConstraint {
+                index_i: i,
+                index_j: j,
+                target_distance: (system.atoms[j].position - system.atoms[i].position).norm(),
+            });
+        }
+        Ok(constraints)
+    }
+
+    pub fn tip3p_constraints_from_system(
+        system: &System,
+    ) -> Result<Vec<DistanceConstraint>, String> {
         if system.atoms.len() != 3 {
             return Err("TIP3P constraint builder expects exactly 3 atoms per molecule.".to_string());
         }
-
-        let oh1 = (system.atoms[1].position - system.atoms[0].position).norm();
-        let oh2 = (system.atoms[2].position - system.atoms[0].position).norm();
-        let hh = (system.atoms[2].position - system.atoms[1].position).norm();
-
-        Ok(vec![(0, 1, oh1), (0, 2, oh2), (1, 2, hh)])
+        constraints_from_pairs(system, &[(0, 1), (0, 2), (1, 2)])
     }
 
     fn shake_bond(
@@ -97,13 +134,16 @@ pub mod shake_rattle {
 
     pub fn apply_shake(
         system: &mut System,
-        constraints: &[(usize, usize, f64)],
+        constraints: &[DistanceConstraint],
         tolerance: f64,
         max_iter: usize,
     ) {
         for _ in 0..max_iter {
             let mut converged = true;
-            for &(i, j, d_ij) in constraints {
+            for constraint in constraints {
+                let i = constraint.index_i;
+                let j = constraint.index_j;
+                let d_ij = constraint.target_distance;
                 let r_vec = system.atoms[j].position - system.atoms[i].position;
                 let error = r_vec.dot(&r_vec) - d_ij.powi(2);
                 if error.abs() >= tolerance {
@@ -119,13 +159,15 @@ pub mod shake_rattle {
 
     pub fn apply_rattle(
         system: &mut System,
-        constraints: &[(usize, usize, f64)],
+        constraints: &[DistanceConstraint],
         tolerance: f64,
         max_iter: usize,
     ) {
         for _ in 0..max_iter {
             let mut converged = true;
-            for &(i, j, _d_ij) in constraints {
+            for constraint in constraints {
+                let i = constraint.index_i;
+                let j = constraint.index_j;
                 let r_vec = system.atoms[j].position - system.atoms[i].position;
                 let v_vec = system.atoms[j].velocity - system.atoms[i].velocity;
                 if r_vec.dot(&v_vec).abs() >= tolerance {

--- a/src/molecule/shake_rattle.rs
+++ b/src/molecule/shake_rattle.rs
@@ -6,104 +6,136 @@ RATTLE: does SHAKE plus an extra correction for velocities
 */
 
 pub mod shake_rattle {
+    use nalgebra::Vector3;
+
     use crate::molecule::molecule::System;
 
-    fn rattle(
-        tolerance: f64,
-        system: &mut System,
-        index_i: usize,
-        index_j: usize,
-        target_distance: f64,
-        max_iter: usize,
-    ) -> () {
-        /*
-        Rattle
-        ------
-
-        Rattle is basicall a velocity/verlet + constraint correction
-
-        -> first correct positions so bond lengths are satisifed
-        -> then correct the velocities so the velocity constraints are satisfied
-
-        Essentially, we are nudging the atoms along the bond direction until the distance matches the target
-
-        so:
-
-        -> if the bond length is too long, pull them together
-        -> if the bond is too short, push them apart
-
-         */
-
-        // compute the inverse masses
-        let inv_mi = 1.0 / system.atoms[index_i].mass;
-        let inv_mj = 1.0 / system.atoms[index_j].mass;
-
-        //let mut lambda_ij = 0.0; //
-        for _ in 0..max_iter {
-            let r_vec = system.atoms[index_j].position - system.atoms[index_i].position; // get vector for position
-            let dist_sq = r_vec.dot(&r_vec); // get the distance squared
-
-            // position correction - for each constrained bond (i,j) with
-            // target distance (target_distance)
-
-            let mut constraint_error = dist_sq - target_distance.powi(2);
-            // we must iteratively adjust positions until constraint_error is roughly 0
-
-            if constraint_error.abs() > tolerance {
-                break;
-            }
-
-            // avoid divide-by-zero
-            if dist_sq < 1e-12 {
-                panic!("Bond distance is too small during RATTLE correction");
-            }
-
-            // approximate the scalar correction
-            let lambda_ij = -constraint_error / (2.0 * (inv_mi + inv_mj) * dist_sq);
-
-            let correction = lambda_ij * r_vec;
-
-            // Apply mass-weighted corrections
-            system.atoms[index_i].position -= correction * inv_mi;
-            system.atoms[index_j].position += correction * inv_mj;
+    pub fn tip3p_constraints_from_system(system: &System) -> Result<Vec<(usize, usize, f64)>, String> {
+        if system.atoms.len() != 3 {
+            return Err("TIP3P constraint builder expects exactly 3 atoms per molecule.".to_string());
         }
+
+        let oh1 = (system.atoms[1].position - system.atoms[0].position).norm();
+        let oh2 = (system.atoms[2].position - system.atoms[0].position).norm();
+        let hh = (system.atoms[2].position - system.atoms[1].position).norm();
+
+        Ok(vec![(0, 1, oh1), (0, 2, oh2), (1, 2, hh)])
     }
 
-    fn shake(
+    fn shake_bond(
         tolerance: f64,
         system: &mut System,
         index_i: usize,
         index_j: usize,
         target_distance: f64,
         max_iter: usize,
-    ) -> () {
-        // Compute the unconstrained trial positions
-        // Enforce position constraints
-        // Accept corrected positions
-
-        // TODO -> need to add more documenatation on how shake works
+    ) {
         let inv_mi = 1.0 / system.atoms[index_i].mass;
         let inv_mj = 1.0 / system.atoms[index_j].mass;
 
         for _ in 0..max_iter {
-            let r_vec = system.atoms[index_j].position - system.atoms[index_i].position; // get v
-            let dist_sq = r_vec.dot(&r_vec); // get the distance squared
+            let r_vec = system.atoms[index_j].position - system.atoms[index_i].position;
+            let dist_sq = r_vec.dot(&r_vec);
             let constraint_error = dist_sq - target_distance.powi(2);
 
             if constraint_error.abs() < tolerance {
                 break;
             }
+
+            if dist_sq <= 1e-12 {
+                break;
+            }
             let denominator = 2.0 * (inv_mi + inv_mj) * dist_sq;
 
-            if denominator.abs() < 1e-12 {
-                panic!("Denominator too small in shake");
+            if denominator <= 1e-12 {
+                break;
             }
 
             let lambda_ij = -constraint_error / denominator;
             let correction = lambda_ij * r_vec;
 
-            system.atoms[index_i].position += correction * inv_mi;
+            system.atoms[index_i].position -= correction * inv_mi;
             system.atoms[index_j].position += correction * inv_mj;
+        }
+    }
+
+    fn rattle_bond(
+        tolerance: f64,
+        system: &mut System,
+        index_i: usize,
+        index_j: usize,
+        max_iter: usize,
+    ) {
+        let inv_mi = 1.0 / system.atoms[index_i].mass;
+        let inv_mj = 1.0 / system.atoms[index_j].mass;
+
+        for _ in 0..max_iter {
+            let r_vec: Vector3<f64> = system.atoms[index_j].position - system.atoms[index_i].position;
+            let v_vec: Vector3<f64> = system.atoms[index_j].velocity - system.atoms[index_i].velocity;
+            let dist_sq = r_vec.dot(&r_vec);
+            if dist_sq <= 1e-12 {
+                break;
+            }
+
+            let constraint_velocity_error = r_vec.dot(&v_vec);
+            if constraint_velocity_error.abs() < tolerance {
+                break;
+            }
+
+            let denominator = (inv_mi + inv_mj) * dist_sq;
+            if denominator <= 1e-12 {
+                break;
+            }
+
+            let mu = -constraint_velocity_error / denominator;
+            let velocity_correction = mu * r_vec;
+
+            system.atoms[index_i].velocity -= velocity_correction * inv_mi;
+            system.atoms[index_j].velocity += velocity_correction * inv_mj;
+        }
+    }
+
+    pub fn apply_shake(
+        system: &mut System,
+        constraints: &[(usize, usize, f64)],
+        tolerance: f64,
+        max_iter: usize,
+    ) {
+        for _ in 0..max_iter {
+            let mut converged = true;
+            for &(i, j, d_ij) in constraints {
+                let r_vec = system.atoms[j].position - system.atoms[i].position;
+                let error = r_vec.dot(&r_vec) - d_ij.powi(2);
+                if error.abs() >= tolerance {
+                    converged = false;
+                }
+                shake_bond(tolerance, system, i, j, d_ij, max_iter);
+            }
+            if converged {
+                break;
+            }
+        }
+    }
+
+    pub fn apply_rattle(
+        system: &mut System,
+        constraints: &[(usize, usize, f64)],
+        tolerance: f64,
+        max_iter: usize,
+    ) {
+        for _ in 0..max_iter {
+            let mut converged = true;
+            for &(i, j, _d_ij) in constraints {
+                let r_vec = system.atoms[j].position - system.atoms[i].position;
+                let v_vec = system.atoms[j].velocity - system.atoms[i].velocity;
+                if r_vec.dot(&v_vec).abs() >= tolerance {
+                    converged = false;
+                }
+                rattle_bond(tolerance, system, i, j, max_iter);
+            }
+            if converged {
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Enforce TIP3P water geometry (O–H, O–H, H–H) during MD so bonded constraints remain satisfied and integration remains stable.
- Provide both position (SHAKE) and velocity (RATTLE) corrections so constrained molecules maintain correct bond lengths and velocity constraints across Verlet steps.

### Description
- Added a `shake_rattle` module in `src/molecule/shake_rattle.rs` with `tip3p_constraints_from_system`, per-bond solvers (`shake_bond`, `rattle_bond`), and high-level APIs `apply_shake` and `apply_rattle` for iterative constraint enforcement.
- Integrated constraint handling into the systems NVE integrator (`run_md_nve_systems` in `src/lib.rs`) by building TIP3P constraint sets once and calling `apply_shake` after position updates (and PBC) and `apply_rattle` after velocity updates.
- Hardened solvers with denominator/division guards and corrected sign/termination behavior to avoid panics on degenerate geometry and to improve convergence.

### Testing
- Ran `cargo check` on the workspace and it completed successfully (with existing unrelated warnings). 
- Ran `cargo check --bin tip3p_water_box` and it completed successfully (with existing unrelated warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cd392ca0832eadce1ae25f9e6fa6)