### PR TITLE
Add logging around TIP3P minimization step

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -55,6 +55,13 @@ fn minimize_systems(
     step_size: f64,
     force_tolerance: f64,
 ) {
+    log::info!(
+        "Starting minimization: max_steps={}, step_size={}, force_tolerance={}",
+        max_steps,
+        step_size,
+        force_tolerance
+    );
+
     for step in 0..max_steps {
         for sys in systems.iter_mut() {
             lennard_jones_simulations::compute_all_bonded_forces_system(sys, box_length);
@@ -75,8 +82,12 @@ fn minimize_systems(
             lennard_jones_simulations::pbc_update(&mut sys.atoms, box_length);
         }
 
+        if step == 0 || (step + 1) % 10 == 0 || step + 1 == max_steps {
+            log::info!("Minimization step {:>4} | max |F| = {:.6}", step + 1, max_force);
+        }
+
         if max_force < force_tolerance {
-            println!(
+            log::info!(
                 "Minimization converged in {} steps (max |F| = {:.6})",
                 step + 1,
                 max_force
@@ -85,7 +96,7 @@ fn minimize_systems(
         }
     }
 
-    println!("Minimization reached max steps without full convergence (max_steps={max_steps})");
+    log::warn!("Minimization reached max steps without full convergence (max_steps={max_steps})");
 }
 
 fn main() -> Result<(), String> {


### PR DESCRIPTION
### Motivation
- Improve observability of the energy minimization stage to aid debugging and to monitor convergence progress during setup.
- Replace ad-hoc `println!` output with structured logging so messages integrate with the existing `env_logger`/`log` setup.

### Description
- Add a start-of-minimization `log::info!` that reports `max_steps`, `step_size`, and `force_tolerance` in `minimize_systems` in `src/bin/tip3p_water_box.rs`.
- Emit periodic progress `log::info!` messages on the first step, every 10 steps, and the final step showing the current maximum force.
- Replace `println!` messages for convergence and non-convergence with `log::info!` and `log::warn!` respectively to use structured logging.

### Testing
- Ran `cargo check --bin tip3p_water_box`, which completed successfully with a single compiler warning about an unused method.
- No runtime tests were executed in this change; logging was added only and build-time checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4485cb098832ebe8dfaaa71ca1ca6)