### PR TITLE
Shorten TIP3P water-box example runtime and relax minimization

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -92,7 +92,11 @@ fn minimize_systems(
         }
 
         if step == 0 || (step + 1) % 25 == 0 || step + 1 == max_steps {
-            log::info!("Minimization step {:>4} | max |F| = {:.6}", step + 1, max_force);
+            log::info!(
+                "Minimization step {:>4} | max |F| = {:.6}",
+                step + 1,
+                max_force
+            );
         }
 
         if max_force < force_tolerance {
@@ -116,11 +120,11 @@ fn main() -> Result<(), String> {
     let n_molecules = (n_side * n_side * n_side) as f64;
     let box_length = (n_molecules / target_number_density).cbrt();
     let dt = 0.001;
-    let nsteps = 20000;
-    let trajectory_stride = 100;
-    let minimization_steps = 200;
+    let nsteps = 1000;
+    let trajectory_stride = 50;
+    let minimization_steps = 50;
     let minimization_step_size = 0.0005;
-    let minimization_force_tolerance = 1e-3;
+    let minimization_force_tolerance = 5e-3;
     let minimization_lj_cutoff = (0.5 * box_length).min(1.2);
     let minimization_pme = PmeConfig {
         alpha: 3.0,
@@ -129,6 +133,12 @@ fn main() -> Result<(), String> {
     };
 
     let mut systems = create_tip3p_water_box(n_side, box_length)?;
+    log::info!(
+        "TIP3P short run config: minimization_steps={}, production_steps={}, dt={}",
+        minimization_steps,
+        nsteps,
+        dt
+    );
     minimize_systems(
         &mut systems,
         box_length,


### PR DESCRIPTION
### Motivation
- Make the TIP3P water-box example run much faster for short-run testing and development iterations.
- Reduce the cost of minimization and trajectory output to speed up CI and local debug runs.

### Description
- Reduced production steps from `20000` to `1000`, and set `trajectory_stride` from `100` to `50` to generate more frequent short-run frames.
- Shortened minimization from `200` to `50` steps and relaxed the minimization force tolerance from `1e-3` to `5e-3` to converge faster for test runs.
- Kept the existing cutoff and PME configuration but preserved `minimization_lj_cutoff` computation; added an informational log line printing the short-run config via `log::info!`.
- Minor formatting cleanup of a `log::info!` call to use a multi-line argument list for readability.

### Testing
- Ran `cargo build` successfully to confirm the code compiles after the changes.
- Ran `cargo test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c507a1abe8832ea329a23e4c396ac2)