### PR TITLE
Stabilize TIP3P minimization and production stepping; harden block averaging

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -57,15 +57,19 @@ fn minimize_systems(
     lj_cutoff: f64,
     pme: PmeConfig,
 ) {
+    let max_displacement_nm = 0.002;
+    let max_force_for_update = 5.0e3;
     log::info!(
-        "Starting minimization: max_steps={}, step_size={}, force_tolerance={}, lj_cutoff={}, pme(alpha={}, real_cutoff={}, kmax={})",
+        "Starting minimization: max_steps={}, step_size={}, force_tolerance={}, lj_cutoff={}, pme(alpha={}, real_cutoff={}, kmax={}), max_displacement_nm={}, max_force_for_update={}",
         max_steps,
         step_size,
         force_tolerance,
         lj_cutoff,
         pme.alpha,
         pme.real_cutoff,
-        pme.kmax
+        pme.kmax,
+        max_displacement_nm,
+        max_force_for_update
     );
 
     for step in 0..max_steps {
@@ -86,7 +90,17 @@ fn minimize_systems(
                 if force_norm > max_force {
                     max_force = force_norm;
                 }
-                atom.position += (step_size / atom.mass) * atom.force;
+                let force_scale = if force_norm > max_force_for_update {
+                    max_force_for_update / force_norm
+                } else {
+                    1.0
+                };
+                let mut displacement = (step_size / atom.mass) * atom.force * force_scale;
+                let displacement_norm = displacement.norm();
+                if displacement_norm > max_displacement_nm {
+                    displacement *= max_displacement_nm / displacement_norm;
+                }
+                atom.position += displacement;
             }
             lennard_jones_simulations::pbc_update(&mut sys.atoms, box_length);
         }
@@ -185,20 +199,18 @@ fn main() -> Result<(), String> {
     let mut frames = Vec::with_capacity((nsteps as usize / trajectory_stride) + 2);
     frames.push(systems_to_particles_frame(&systems));
 
-    for step in 0..nsteps {
+    for completed_steps in (0..nsteps).step_by(trajectory_stride as usize) {
+        let steps_this_chunk = (nsteps - completed_steps).min(trajectory_stride) as i32;
         lennard_jones_simulations::run_md_nve_systems_with_constraints_and_config(
             &mut systems,
-            1,
+            steps_this_chunk,
             dt,
             box_length,
             "none",
             Some(&constraint_options),
             run_config,
         );
-
-        if (step + 1) % trajectory_stride == 0 || step + 1 == nsteps {
-            frames.push(systems_to_particles_frame(&systems));
-        }
+        frames.push(systems_to_particles_frame(&systems));
     }
 
     write_gro_systems(

--- a/src/error/error.rs
+++ b/src/error/error.rs
@@ -16,6 +16,14 @@ pub fn compute_average_val(
     
  */
 {
+    if block_steps == 0 {
+        log::warn!("Invalid block configuration: block_steps must be > 0");
+        return;
+    }
+    if container_value.is_empty() {
+        log::warn!("No values provided for block averaging");
+        return;
+    }
     if number_of_steps % block_steps != 0 {
         log::warn!("Invalid block configuration: number_of_steps={number_of_steps}, block_steps={block_steps}");
     }
@@ -24,9 +32,10 @@ pub fn compute_average_val(
 
     for (i, chunk) in container_value.chunks(block_steps as usize).enumerate() {
         let summed_values: f32 = chunk.iter().sum();
+        let chunk_len = chunk.len() as f32;
         log::info!(
             "Block {i:>4} | avg={:.6} (block size={block_steps})",
-            summed_values / block_steps as f32
+            summed_values / chunk_len
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Minimization could produce extremely large forces and runaway coordinate updates leading to catastrophic energies at integration start, and production was invoking the integrator in 1-step increments which triggered repeated invalid block-size warnings.
- Block-averaging code did not guard against zero block size or empty input and used a fixed divisor that could misreport averages for partial final chunks.

### Description
- In `src/bin/tip3p_water_box.rs` added `max_displacement_nm` and `max_force_for_update` and scale/clamp per-atom minimization displacements to prevent runaway updates during minimization.
- In `src/bin/tip3p_water_box.rs` changed the production loop to run in chunked calls of size `trajectory_stride` (converted to `i32`) and collect frames once per chunk to avoid calling the integrator with `1` step repeatedly.
- In `src/error/error.rs` hardened `compute_average_val` to early-return on `block_steps == 0` or empty `container_value` and compute each block average using the actual chunk length.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo check --bin tip3p_water_box` and fixed an initial type mismatch; final `cargo check` completed successfully with one unrelated `dead_code` warning in `src/cell/cell.rs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c526747128832eae35e44bf4ce498e)