### PR TITLE
Speed up TIP3P sanity-check simulation

### DIFF
--- a/src/bin/tip3p_water_box.rs
+++ b/src/bin/tip3p_water_box.rs
@@ -129,26 +129,28 @@ fn minimize_systems(
 fn main() -> Result<(), String> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    let n_side = 6;
+    // Intentionally tiny box for quick VMD sanity checks.
+    let n_side = 3;
     let target_number_density = 33.3679; // molecules / nm^3 (~1 g/cm^3 water)
     let n_molecules = (n_side * n_side * n_side) as f64;
     let box_length = (n_molecules / target_number_density).cbrt();
     let dt = 0.001;
-    let nsteps = 1000;
-    let trajectory_stride = 50;
-    let minimization_steps = 50;
-    let minimization_step_size = 0.0005;
-    let minimization_force_tolerance = 5e-3;
-    let minimization_lj_cutoff = (0.5 * box_length).min(1.2);
+    let nsteps = 120;
+    let trajectory_stride = 20;
+    let minimization_steps = 8;
+    let minimization_step_size = 0.0008;
+    let minimization_force_tolerance = 5e-2;
+    let minimization_lj_cutoff = (0.5 * box_length).min(1.0);
     let minimization_pme = PmeConfig {
         alpha: 3.0,
         real_cutoff: minimization_lj_cutoff,
-        kmax: 4,
+        kmax: 2,
     };
 
     let mut systems = create_tip3p_water_box(n_side, box_length)?;
     log::info!(
-        "TIP3P short run config: minimization_steps={}, production_steps={}, dt={}",
+        "TIP3P quick sanity config: n_side={}, minimization_steps={}, production_steps={}, dt={}",
+        n_side,
         minimization_steps,
         nsteps,
         dt
@@ -184,15 +186,15 @@ fn main() -> Result<(), String> {
         max_iter: 100,
     };
 
-    let cutoff = (0.5 * box_length).min(1.2);
+    let cutoff = (0.5 * box_length).min(1.0);
     let run_config = SystemSimulationConfig {
         cutoff,
-        neighbor_skin: 0.2,
-        neighbor_rebuild_interval: 10,
+        neighbor_skin: 0.15,
+        neighbor_rebuild_interval: 20,
         pme: PmeConfig {
             alpha: 3.5,
             real_cutoff: cutoff,
-            kmax: 6,
+            kmax: 3,
         },
     };
 


### PR DESCRIPTION
### Motivation
- The TIP3P demo run was too large and slow for quick visual sanity checks in VMD, so a much smaller, faster smoke-test configuration is needed.
- Minimization and production settings were heavy for a quick check and should be relaxed to reduce startup time.

### Description
- Reduced the system size by setting `n_side` from `6` to `3` to create a tiny `3x3x3` water box for fast rendering and inspection.
- Shortened production by changing `nsteps` from `1000` to `120` and reduced output size by changing `trajectory_stride` from `50` to `20`.
- Cut minimization work by changing `minimization_steps` `50 -> 8`, relaxed `minimization_force_tolerance` `5e-3 -> 5e-2`, and adjusted `minimization_step_size` and minimization PME `kmax` to speed convergence.
- Tuned runtime nonbonded settings for quick runs by capping cutoffs to `min(..., 1.0)`, lowering production PME `kmax`, reducing `neighbor_skin`, and increasing `neighbor_rebuild_interval`, and updated the run log message to reflect the quick sanity config.

### Testing
- Ran `cargo check --bin tip3p_water_box` which completed successfully (build finished for the `tip3p_water_box` binary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f7e22ee0832eaadd5e41e0cdf1dc)