### PR TITLE
Add Rust VMD-style trajectory viewer scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,18 @@ parameterized = "2.1.0"
 xdrfile = "0.3.0"
 mpi = { version = "0.8", optional = true }
 pyo3 = { version = "0.22", optional = true, features = ["extension-module"] }
+macroquad = { version = "0.4", optional = true }
 
 [features]
 default = []
 mpi = ["dep:mpi"]
 python = ["dep:pyo3"]
+viewer = ["dep:macroquad"]
 
 [profile.release]
 panic = "abort"
+
+[[bin]]
+name = "vmd_viewer"
+path = "src/bin/vmd_viewer.rs"
+required-features = ["viewer"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ Generated files:
 > - This is a coarse-grained, point-particle fluid setup (water-like in mass/density intent, not explicit 3-site/4-site water geometry).
 > - Coordinates are written in GRO/XTC-compatible units (nm in files).
 
+## 🖥️ Rust VMD-style trajectory viewer (workbench starter)
+
+A new interactive viewer binary is included as a Rust-first starting point for trajectory visualization workflows.
+It loads a `GRO` structure and optionally an `XTC` trajectory, then renders atoms in a 3D viewport with playback controls.
+
+Run it with:
+
+```bash
+cargo run --features viewer --bin vmd_viewer -- water_box.gro water_box.xtc
+```
+
+Controls:
+- `Space`: play/pause
+- `←` / `→`: step one frame
+- `↑` / `↓`: playback FPS
+- Left mouse drag: orbit camera
+- Mouse wheel: zoom
+
+This is intentionally a scaffold so you can extend it in Rust (atom coloring, bonds, selection, measure tools, rendering styles, etc.).
+
+---
+
 ## 🐍 Python interface (buildable scaffold)
 
 A minimal Python extension interface is available behind the `python` feature.

--- a/src/bin/vmd_viewer.rs
+++ b/src/bin/vmd_viewer.rs
@@ -1,0 +1,213 @@
+use macroquad::prelude::*;
+use sang_md::visualization::{load_trajectory, TrajectoryData};
+
+const DEFAULT_FPS: f32 = 24.0;
+
+fn window_conf() -> Conf {
+    Conf {
+        window_title: "FerrumMD VMD-style Viewer".to_string(),
+        window_width: 1280,
+        window_height: 720,
+        ..Default::default()
+    }
+}
+
+fn parse_args() -> Result<(String, Option<String>), String> {
+    let mut args = std::env::args().skip(1);
+    let gro_path = args.next().ok_or_else(|| {
+        "usage: cargo run --features viewer --bin vmd_viewer -- <structure.gro> [trajectory.xtc]"
+            .to_string()
+    })?;
+    let xtc_path = args.next();
+    Ok((gro_path, xtc_path))
+}
+
+fn bounds_for_frame(
+    points: &[nalgebra::Vector3<f32>],
+) -> (nalgebra::Vector3<f32>, nalgebra::Vector3<f32>) {
+    let mut min_v = points[0];
+    let mut max_v = points[0];
+
+    for point in points.iter().skip(1) {
+        min_v.x = min_v.x.min(point.x);
+        min_v.y = min_v.y.min(point.y);
+        min_v.z = min_v.z.min(point.z);
+
+        max_v.x = max_v.x.max(point.x);
+        max_v.y = max_v.y.max(point.y);
+        max_v.z = max_v.z.max(point.z);
+    }
+
+    (min_v, max_v)
+}
+
+fn compute_scale(data: &TrajectoryData) -> f32 {
+    let first_frame = &data.frames[0].positions_nm;
+    let (min_v, max_v) = bounds_for_frame(first_frame);
+    let extent = max_v - min_v;
+    let max_extent = extent.x.max(extent.y).max(extent.z);
+    if max_extent <= f32::EPSILON {
+        1.0
+    } else {
+        12.0 / max_extent
+    }
+}
+
+fn draw_box(box_dims_nm: nalgebra::Vector3<f32>, scale: f32, color: Color) {
+    let x = box_dims_nm.x * scale;
+    let y = box_dims_nm.y * scale;
+    let z = box_dims_nm.z * scale;
+
+    let p000 = vec3(0.0, 0.0, 0.0);
+    let p100 = vec3(x, 0.0, 0.0);
+    let p010 = vec3(0.0, y, 0.0);
+    let p110 = vec3(x, y, 0.0);
+
+    let p001 = vec3(0.0, 0.0, z);
+    let p101 = vec3(x, 0.0, z);
+    let p011 = vec3(0.0, y, z);
+    let p111 = vec3(x, y, z);
+
+    for (a, b) in [
+        (p000, p100),
+        (p000, p010),
+        (p000, p001),
+        (p100, p110),
+        (p100, p101),
+        (p010, p110),
+        (p010, p011),
+        (p110, p111),
+        (p001, p101),
+        (p001, p011),
+        (p101, p111),
+        (p011, p111),
+    ] {
+        draw_line_3d(a, b, color);
+    }
+}
+
+#[macroquad::main(window_conf)]
+async fn main() {
+    let (gro_path, xtc_path) = match parse_args() {
+        Ok(values) => values,
+        Err(message) => {
+            eprintln!("{message}");
+            return;
+        }
+    };
+
+    let data = match load_trajectory(&gro_path, xtc_path.as_deref()) {
+        Ok(data) => data,
+        Err(message) => {
+            eprintln!("trajectory load failed: {message}");
+            return;
+        }
+    };
+
+    let mut frame_idx = 0usize;
+    let mut playing = true;
+    let mut fps = DEFAULT_FPS;
+    let mut elapsed = 0.0f32;
+    let mut yaw = -0.6f32;
+    let mut pitch = 0.6f32;
+    let mut radius = 24.0f32;
+
+    let scale = compute_scale(&data);
+
+    loop {
+        let dt = get_frame_time();
+        clear_background(BLACK);
+
+        if is_key_pressed(KeyCode::Space) {
+            playing = !playing;
+        }
+        if is_key_pressed(KeyCode::Right) {
+            frame_idx = (frame_idx + 1) % data.frames.len();
+            playing = false;
+        }
+        if is_key_pressed(KeyCode::Left) {
+            frame_idx = frame_idx.checked_sub(1).unwrap_or(data.frames.len() - 1);
+            playing = false;
+        }
+        if is_key_pressed(KeyCode::Up) {
+            fps = (fps + 6.0).min(120.0);
+        }
+        if is_key_pressed(KeyCode::Down) {
+            fps = (fps - 6.0).max(1.0);
+        }
+
+        let (mouse_dx, mouse_dy) = mouse_delta_position();
+        if is_mouse_button_down(MouseButton::Left) {
+            yaw -= mouse_dx * 0.01;
+            pitch = (pitch + mouse_dy * 0.01).clamp(-1.4, 1.4);
+        }
+
+        let (_, wheel_y) = mouse_wheel();
+        radius = (radius - wheel_y * 1.5).clamp(4.0, 100.0);
+
+        if playing && data.frames.len() > 1 {
+            elapsed += dt;
+            let frame_period = 1.0 / fps;
+            while elapsed >= frame_period {
+                elapsed -= frame_period;
+                frame_idx = (frame_idx + 1) % data.frames.len();
+            }
+        }
+
+        let frame = &data.frames[frame_idx];
+        let mut center = vec3(0.0, 0.0, 0.0);
+        for point in &frame.positions_nm {
+            center += vec3(point.x * scale, point.y * scale, point.z * scale);
+        }
+        center /= frame.positions_nm.len() as f32;
+
+        let camera_pos = vec3(
+            center.x + radius * yaw.cos() * pitch.cos(),
+            center.y + radius * pitch.sin(),
+            center.z + radius * yaw.sin() * pitch.cos(),
+        );
+
+        set_camera(&Camera3D {
+            position: camera_pos,
+            up: vec3(0.0, 1.0, 0.0),
+            target: center,
+            ..Default::default()
+        });
+
+        for point in &frame.positions_nm {
+            let position = vec3(point.x * scale, point.y * scale, point.z * scale);
+            draw_sphere(position, 0.16, None, SKYBLUE);
+        }
+
+        if let Some(box_dims) = data.box_dims_nm {
+            draw_box(box_dims, scale, GRAY);
+        }
+
+        set_default_camera();
+        draw_text(
+            &format!(
+                "FerrumMD Viewer | atoms: {} | frame: {}/{} | step: {} | t = {:.3} ps",
+                data.atom_count,
+                frame_idx + 1,
+                data.frames.len(),
+                frame.step,
+                frame.time_ps,
+            ),
+            20.0,
+            30.0,
+            28.0,
+            WHITE,
+        );
+        draw_text(
+            &format!(
+                "Space: play/pause | ←/→: step | ↑/↓: FPS ({fps:.0}) | Drag: orbit | Wheel: zoom"
+            ),
+            20.0,
+            58.0,
+            24.0,
+            LIGHTGRAY,
+        );
+
+        next_frame().await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod python;
 #[path = "quantum/quantum_chem.rs"]
 pub mod quantum_chemistry;
 pub mod thermostat_barostat;
+pub mod visualization;
 
 use std::collections::HashSet;
 

--- a/src/visualization/mod.rs
+++ b/src/visualization/mod.rs
@@ -1,0 +1,101 @@
+use crate::lennard_jones_simulations::Particle;
+use crate::molecule::io::read_gro;
+use nalgebra::Vector3;
+use xdrfile::{Frame, Trajectory, XTCTrajectory};
+
+#[derive(Clone, Debug)]
+pub struct TrajectoryFrame {
+    pub step: usize,
+    pub time_ps: f32,
+    pub positions_nm: Vec<Vector3<f32>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TrajectoryData {
+    pub atom_count: usize,
+    pub box_dims_nm: Option<Vector3<f32>>,
+    pub frames: Vec<TrajectoryFrame>,
+}
+
+fn particles_to_positions(particles: &[Particle]) -> Vec<Vector3<f32>> {
+    particles
+        .iter()
+        .map(|particle| {
+            Vector3::new(
+                particle.position.x as f32,
+                particle.position.y as f32,
+                particle.position.z as f32,
+            )
+        })
+        .collect()
+}
+
+pub fn load_trajectory(gro_path: &str, xtc_path: Option<&str>) -> Result<TrajectoryData, String> {
+    let (particles, gro_box_dims) = read_gro(gro_path)?;
+    let atom_count = particles.len();
+
+    if atom_count == 0 {
+        return Err("GRO file has zero atoms; cannot visualize an empty system".to_string());
+    }
+
+    let mut frames = Vec::new();
+    let mut box_dims_nm = gro_box_dims.map(|v| Vector3::new(v.x as f32, v.y as f32, v.z as f32));
+
+    if let Some(path) = xtc_path {
+        let mut trajectory =
+            XTCTrajectory::open_read(path).map_err(|e| format!("failed to open xtc file: {e}"))?;
+
+        let xtc_atom_count = trajectory
+            .get_num_atoms()
+            .map_err(|e| format!("failed to read atom count from xtc: {e}"))?;
+
+        if xtc_atom_count != atom_count {
+            return Err(format!(
+                "atom count mismatch between GRO ({atom_count}) and XTC ({xtc_atom_count})"
+            ));
+        }
+
+        loop {
+            let mut frame = Frame::with_len(atom_count);
+            match trajectory.read(&mut frame) {
+                Ok(()) => {
+                    if box_dims_nm.is_none() {
+                        box_dims_nm = Some(Vector3::new(
+                            frame.box_vector[0][0],
+                            frame.box_vector[1][1],
+                            frame.box_vector[2][2],
+                        ));
+                    }
+
+                    frames.push(TrajectoryFrame {
+                        step: frame.step,
+                        time_ps: frame.time,
+                        positions_nm: frame
+                            .coords
+                            .iter()
+                            .map(|coord| Vector3::new(coord[0], coord[1], coord[2]))
+                            .collect(),
+                    });
+                }
+                Err(err) if err.is_eof() => break,
+                Err(err) => {
+                    return Err(format!("failed while reading xtc trajectory frame: {err}"));
+                }
+            }
+        }
+    }
+
+    if frames.is_empty() {
+        frames.push(TrajectoryFrame {
+            step: 0,
+            time_ps: 0.0,
+            positions_nm: particles_to_positions(&particles),
+        });
+    }
+
+    Ok(TrajectoryData {
+        atom_count,
+        box_dims_nm,
+        frames,
+    })
+}


### PR DESCRIPTION
### Motivation
- Provide a Rust-native, VMD-style interactive visualization scaffold so trajectories produced by the MD engine can be inspected and extended in Rust.
- Offer a minimal, well-structured starting point for common viewer features (frame playback, camera orbit/zoom, box rendering, and per-atom rendering) that can be iterated on by developers.

### Description
- Add a new visualization module `src/visualization/mod.rs` exposing `TrajectoryFrame`, `TrajectoryData`, and `load_trajectory(gro_path, xtc_path)` that reads `GRO` + optional `XTC`, validates atom-count consistency, and gracefully handles EOF or GRO-only cases.
- Add an interactive viewer binary `src/bin/vmd_viewer.rs` (gated by a new `viewer` feature) implemented with `macroquad` and supporting play/pause, step, FPS control, orbit/zoom camera controls, atom rendering, and box edge drawing.
- Wire the viewer into the crate by adding an optional `macroquad` dependency and a `viewer` feature in `Cargo.toml` and register the `vmd_viewer` binary as a feature-gated `[[bin]]` entry.
- Export the `visualization` module from the library (`pub mod visualization;`) and document usage and controls in `README.md` with a short example `cargo run --features viewer --bin vmd_viewer -- <structure.gro> [trajectory.xtc]`.

### Testing
- Ran `cargo fmt`, which completed successfully. 
- Ran `cargo check` but it failed in this environment due to inability to reach the crates.io index (network/CONNECT tunnel HTTP 403). 
- Ran `cargo check --features viewer --bin vmd_viewer` but it failed for the same crates.io network restriction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e223894e64832e84214cd2bdeecf55)