### PR TITLE
Stabilize Martini water-box demo by reducing timestep and tightening thermostat

### DIFF
--- a/src/bin/martini_water_box.rs
+++ b/src/bin/martini_water_box.rs
@@ -110,9 +110,11 @@ fn main() -> Result<(), String> {
     let sigma = 0.47;
     let epsilon = 0.2;
     let box_length = 8.0;
-    let dt = 0.02;
+    // A conservative CG integration step helps avoid occasional LJ blow-ups
+    // from rare close contacts in this simple demo setup.
+    let dt = 0.005;
     let nsteps = 2000;
-    let thermostat_tau = 0.05;
+    let thermostat_tau = 0.02;
 
     let mut particles =
         create_martini_water_box(n_side, box_length, target_temperature, mass, sigma, epsilon)?;


### PR DESCRIPTION
### Motivation

- The demo exhibited intermittent temperature blow-ups from rare close contacts in the simple LJ CG setup, so the integration and thermostat coupling were made more conservative to improve robustness.

### Description

- Reduced the integration timestep in `src/bin/martini_water_box.rs` from `0.02` to `0.005` and added an inline comment explaining the reason. 
- Tightened the Berendsen thermostat coupling by changing `thermostat_tau` from `0.05` to `0.02`.

### Testing

- Ran `cargo fmt --all`, which completed successfully. 
- Attempted `cargo check --bin martini_water_box`, which failed due to network access to crates.io (download of `macroquad` failed with HTTP 403) and prevented full build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e227775134832eab0aab0f8090a929)