### PR TITLE
Stabilize martini_water_box NVT production run

### DIFF
--- a/src/bin/martini_water_box.rs
+++ b/src/bin/martini_water_box.rs
@@ -37,11 +37,8 @@ fn create_martini_water_box(
                     (iz as f64 + 0.5) * spacing + rng.random_range(-jitter..jitter),
                 );
 
-                let velocity = Vector3::new(
-                    normal.sample(&mut rng),
-                    normal.sample(&mut rng),
-                    normal.sample(&mut rng),
-                );
+                let velocity =
+                    Vector3::new(normal.sample(rng), normal.sample(rng), normal.sample(rng));
 
                 particles.push(Particle {
                     id: particles.len(),
@@ -112,12 +109,13 @@ fn main() -> Result<(), String> {
     let sigma = 0.47;
     let epsilon = 0.2;
     let box_length = 8.0;
-    // A conservative CG integration step helps avoid occasional LJ blow-ups
-    // from rare close contacts in this simple demo setup.
-    let dt = 0.005;
+    // Keep the integration step small for this simple reduced-unit setup to
+    // avoid catastrophic close-contact accelerations in production.
+    let dt = 0.0002;
     let nsteps_equil = 500;
     let nsteps_prod = 1500;
-    let thermostat_tau = 0.02;
+    let equil_thermostat_tau = 0.02;
+    let prod_thermostat_tau = 0.1;
     let cell_subdivisions = 10;
     let total_steps = nsteps_equil + nsteps_prod;
 
@@ -176,14 +174,17 @@ fn main() -> Result<(), String> {
             p.velocity += 0.5 * a_new * dt;
         }
 
-        if step < nsteps_equil {
-            apply_thermostat_berendsen_particles(
-                &mut particles,
-                target_temperature,
-                thermostat_tau,
-                dt,
-            );
-        }
+        let thermostat_tau = if step < nsteps_equil {
+            equil_thermostat_tau
+        } else {
+            prod_thermostat_tau
+        };
+        apply_thermostat_berendsen_particles(
+            &mut particles,
+            target_temperature,
+            thermostat_tau,
+            dt,
+        );
         if step % 50 == 0 {
             remove_center_of_mass_drift(&mut particles);
         }


### PR DESCRIPTION
### Motivation
- Address catastrophic temperature blow-ups observed during production in the `martini_water_box` NVT demo by improving thermostat handling and integration parameters. 
- Fix incorrect RNG usage with `rand_distr` so velocity sampling compiles and behaves as intended under the current API. 

### Description
- Use `normal.sample(rng)` for velocity sampling to correctly use the mutable RNG reference with `rand_distr`. 
- Apply the Berendsen thermostat in both equilibration and production phases and select the coupling time per-step with `equil_thermostat_tau = 0.02` and `prod_thermostat_tau = 0.1`. 
- Reduce the integration timestep from `0.005` to `0.0002` to avoid late-stage large accelerations from close LJ contacts and stabilize long runs. 

### Testing
- Ran `cargo fmt`, which completed successfully. 
- Ran `cargo check --bin martini_water_box`, which completed successfully with only an unrelated `dead_code` warning. 
- Ran `cargo run --bin martini_water_box` for the full 2000-step demo, observed stable temperatures through production (~301.3 K) and successful output of `martini_water_box.gro` and `martini_water_box.xtc`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2412ba994832eb89db2ad799f2ddc)