### PR TITLE
Fix compile error in lennard_jones_simulations module

### DIFF
--- a/src/lennard_jones_simulations/mod.rs
+++ b/src/lennard_jones_simulations/mod.rs
@@ -512,10 +512,6 @@ fn sample_position_with_min_separation(
 //                for s in sys.atoms.iter_mut() {
 //                    let a_new = s.force / s.mass; // compu
 //                    s.update_velocity_verlet(a_new, dt);
-//<<<<<<< codex/merge-rust-files-into-directory-n8v43r
-253
- 
-
 //                    println!(
 //                        "After a iteration step, the position and velocity is {:?} and {:?} ",
 //                        s.position, s.velocity


### PR DESCRIPTION
### Motivation
- Remove a leftover merge-artifact stray token that caused the parser error `expected item` during Rust compilation.

### Description
- Deleted merge markers and the stray `253` token from `src/lennard_jones_simulations/mod.rs` so the module parses as valid Rust.

### Testing
- Ran `cargo build` and the build finished successfully (one unrelated `dead_code` warning was emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134a8d3c2c832eb229f0009203c029)