### PR TITLE
Revamp FerrumMD Beamer deck: restructure content and emphasize Rust advantages

### DIFF
--- a/latex/ferrummd_rust_audience_beamer.tex
+++ b/latex/ferrummd_rust_audience_beamer.tex
@@ -6,8 +6,8 @@
 \usepackage{amsmath}
 \usepackage{booktabs}
 
-\title{FerrumMD: Molecular Dynamics in Rust}
-\subtitle{Main components for Rust developers new to MD}
+\title{FerrumMD: A Gentle Introduction to Molecular Dynamics in Rust}
+\subtitle{What molecular dynamics is, what FerrumMD does, and where Rust helps}
 \author{FerrumMD project overview}
 \date{\today}
 
@@ -17,130 +17,290 @@
   \titlepage
 \end{frame}
 
-\begin{frame}{Why this project matters}
+\begin{frame}{Who this talk is for}
 \begin{itemize}
-  \item \textbf{Goal:} build an MD engine with Rust's safety + performance model.
-  \item \textbf{Audience bridge:} map familiar systems ideas (data layout, kernels, parallelism) to simulation workflows.
-  \item \textbf{Scope today:} short-range interactions, molecular topologies, integrators, thermodynamic controls, and I/O.
+  \item People who are curious about scientific computing, Rust, or molecular simulation.
+  \item No molecular dynamics (MD) background is assumed.
+  \item You only need three ideas:
+  \begin{enumerate}
+    \item atoms and molecules can be modeled as particles,
+    \item particles move because forces act on them,
+    \item a computer simulation repeats a small update many times.
+  \end{enumerate}
+\end{itemize}
+\end{frame}
+
+\begin{frame}{What problem does molecular dynamics solve?}
+\begin{itemize}
+  \item Experiments can show what molecules do, but not always every tiny motion.
+  \item MD creates a computational ``movie'' of atoms and molecules over time.
+  \item Typical questions:
+  \begin{itemize}
+    \item How does a liquid arrange itself?
+    \item Does a molecule remain stable?
+    \item How do temperature, pressure, or force-field choices affect behavior?
+  \end{itemize}
+  \item FerrumMD is a Rust codebase for building and studying these simulation workflows.
 \end{itemize}
 \end{frame}
 
 \begin{frame}{MD in one minute}
+\begin{block}{Basic idea}
+Start with positions and velocities, compute forces, then move everything a tiny bit.
+\end{block}
+\begin{enumerate}
+  \item Read or build a molecular system.
+  \item Compute forces from the current geometry.
+  \item Update positions and velocities using Newton's laws.
+  \item Keep particles inside the simulation box and apply controls.
+  \item Save energies, temperatures, and trajectory frames.
+\end{enumerate}
+\vspace{0.5em}
+\centering
+\texttt{state $\rightarrow$ forces $\rightarrow$ updated state $\rightarrow$ repeat}
+\end{frame}
+
+\begin{frame}{A few useful words}
+\begin{description}
+  \item[Particle] An atom or coarse-grained bead with a position, velocity, and mass.
+  \item[Force field] Parameters and formulas that approximate molecular forces.
+  \item[Integrator] The numerical method that advances the simulation clock.
+  \item[Trajectory] The saved sequence of molecular snapshots.
+  \item[Ensemble] The thermodynamic conditions being approximated, such as constant energy or temperature.
+\end{description}
+\end{frame}
+
+\begin{frame}{Why this project matters}
 \begin{itemize}
-  \item MD evolves particle positions/velocities by integrating Newton's equations.
-  \item Core loop per step:
-  \begin{enumerate}
-    \item compute forces from current geometry,
-    \item update positions/velocities,
-    \item apply boundary conditions and controls (thermostat/barostat),
-    \item report observables and save trajectory.
-  \end{enumerate}
-  \item Think of it as a repeated \texttt{state -> forces -> state'} transform with strict numerical constraints.
+  \item \textbf{Learning value:} FerrumMD exposes the pieces of an MD engine in a readable systems language.
+  \item \textbf{Engineering value:} Rust's ownership model helps organize mutable simulation state safely.
+  \item \textbf{Scientific value:} explicit units, tests, and reproducible workflows are central to trustworthy simulations.
+  \item \textbf{Scope today:} the main building blocks rather than production-scale chemistry.
 \end{itemize}
 \end{frame}
 
-\begin{frame}{High-level FerrumMD architecture}
-\begin{block}{Data and state}
-\texttt{state}, \texttt{molecule}, \texttt{parameters}, \texttt{cell}, \texttt{cell\_subdivision}
-\end{block}
-\begin{block}{Physics kernels}
-\texttt{lennard\_jones}, bonded interactions, electrostatics roadmap, free-energy and quantum modules
-\end{block}
-\begin{block}{Control and workflows}
-\texttt{ensembles} (NVE/NVT/NPT), \texttt{thermostat\_barostat}, minimization, replica exchange
-\end{block}
-\begin{block}{Interfaces}
-CLI binaries, GRO/XTC trajectory output, optional viewer feature, optional Python + MPI features
-\end{block}
-\end{frame}
-
-\begin{frame}{Core simulation state (Rust view)}
-\begin{itemize}
-  \item Struct-based system representation for particles, molecules, box, and parameters.
-  \item Explicit unit convention (nm, ps, amu, kJ/mol) avoids hidden conversion bugs.
-  \item Rust typing helps separate concerns:
-  \begin{itemize}
-    \item immutable parameter sets,
-    \item mutable evolving state,
-    \item module boundaries for force kernels and integration.
-  \end{itemize}
-  \item Result: easier reasoning about correctness and reproducibility.
-\end{itemize}
-\end{frame}
-
-\begin{frame}{Force models implemented}
+\begin{frame}{FerrumMD at a glance}
 \begin{columns}[T]
-\column{0.52\textwidth}
-\textbf{Nonbonded}
+\column{0.48\textwidth}
+\textbf{Simulation core}
 \begin{itemize}
-  \item Lennard--Jones pair interaction
-  \item Minimum-image convention with periodic boundary conditions
-  \item Cell subdivision module for scaling pair computations
+  \item particle and molecule state
+  \item simulation box and periodic boundaries
+  \item Lennard--Jones and bonded forces
+  \item velocity-Verlet time stepping
 \end{itemize}
 
-\column{0.45\textwidth}
-\textbf{Bonded}
+\column{0.48\textwidth}
+\textbf{Workflow support}
 \begin{itemize}
-  \item Harmonic bond forces
-  \item Support for small molecular systems (e.g., H$_2$)
-  \item Topology readers for Martini/CHARMM-style inputs
+  \item temperature and pressure controls
+  \item input/output for common file formats
+  \item example water-like systems
+  \item optional viewer, Python, and MPI paths
 \end{itemize}
 \end{columns}
 \end{frame}
 
-\begin{frame}{Time integration and thermodynamic control}
+\begin{frame}{The simulation state: what the program stores}
 \begin{itemize}
-  \item Velocity-Verlet integrator as the default engine.
-  \item Ensemble support:
+  \item \textbf{Coordinates:} where each particle is in the box.
+  \item \textbf{Velocities:} how fast each particle is moving.
+  \item \textbf{Forces:} the current push or pull on each particle.
+  \item \textbf{Parameters:} masses, charges, bond constants, and interaction strengths.
+  \item \textbf{Box:} the finite volume that stands in for a larger material.
+\end{itemize}
+\begin{block}{Unit convention}
+FerrumMD keeps units explicit: nm, ps, amu, and kJ/mol.
+\end{block}
+\end{frame}
+
+\begin{frame}{Forces: how particles influence each other}
+\begin{columns}[T]
+\column{0.52\textwidth}
+\textbf{Nonbonded interactions}
+\begin{itemize}
+  \item Lennard--Jones models short-range attraction and repulsion.
+  \item Periodic boundaries make the small box behave more like bulk matter.
+  \item Cell subdivision reduces the number of pair checks.
+\end{itemize}
+
+\column{0.45\textwidth}
+\textbf{Bonded interactions}
+\begin{itemize}
+  \item Harmonic bonds act like springs between connected atoms.
+  \item Small molecular examples make the math easier to inspect.
+  \item Topology readers help import force-field definitions.
+\end{itemize}
+\end{columns}
+\end{frame}
+
+\begin{frame}{Time stepping: turning forces into motion}
+\begin{itemize}
+  \item FerrumMD uses velocity-Verlet as a central integration method.
+  \item Each step is tiny, so many steps are needed for a useful trajectory.
+  \item The integrator must balance speed, stability, and energy behavior.
+  \item Initialization can sample velocities from a Maxwell--Boltzmann distribution.
+\end{itemize}
+\begin{block}{Beginner mental model}
+It is like a physics game loop, but numerical accuracy and units matter much more.
+\end{block}
+\end{frame}
+
+\begin{frame}{Temperature, pressure, and ensembles}
+\begin{itemize}
+  \item Real experiments often control temperature or pressure.
+  \item MD approximates these conditions with \emph{ensembles}:
   \begin{itemize}
-    \item NVE (energy-conserving baseline),
-    \item pseudo-NVT/NVT with thermostats,
-    \item NPT path with isotropic barostat support.
+    \item NVE: constant particles, volume, and energy,
+    \item NVT: constant particles, volume, and temperature,
+    \item NPT: constant particles, pressure, and temperature.
   \end{itemize}
-  \item Thermostats implemented: Berendsen and Nose--Hoover.
-  \item Initialization: Maxwell--Boltzmann velocity sampling.
+  \item FerrumMD includes thermostat and barostat paths, including Berendsen and Nose--Hoover thermostats.
 \end{itemize}
 \end{frame}
 
-\begin{frame}{I/O and ecosystem interoperability}
+\begin{frame}{Inputs, outputs, and visualization}
 \begin{itemize}
-  \item Reads molecular inputs: PDB, GRO, LAMMPS data/dump.
-  \item Force-field conversion helpers: Martini and CHARMM parsers.
-  \item Writes GRO/XTC outputs for external visualization (e.g., VMD).
-  \item Includes a Rust-native viewer scaffold (feature-gated) for extension in pure Rust.
-  \item Python bindings scaffold and MPI-enabled path for integration and parallel demos.
+  \item Read starting structures and parameters from familiar molecular formats.
+  \item Supported inputs include PDB, GRO, LAMMPS data/dump, Martini, and CHARMM-style files.
+  \item Write GRO/XTC outputs so trajectories can be viewed in external tools such as VMD.
+  \item Optional Rust viewer and Python bindings provide extension points for demos and analysis.
 \end{itemize}
 \end{frame}
 
-\begin{frame}{Why Rust is interesting here}
+\begin{frame}{The honest Rust pitch}
+\begin{block}{Not the claim}
+Rust does \emph{not} make an MD engine automatically faster than C++.
+Well-written C++ MD engines can be extremely fast.
+\end{block}
+\begin{block}{The stronger claim}
+Rust offers C/C++-level native performance while making many dangerous scientific-code bugs harder to write.
+\end{block}
 \begin{itemize}
-  \item \textbf{Safety:} ownership/borrowing reduces hidden aliasing in mutable simulation state.
-  \item \textbf{Performance:} predictable data-oriented code, low abstraction penalty.
-  \item \textbf{Composability:} feature flags (MPI/viewer/python) keep core minimal.
-  \item \textbf{Reliability culture:} strong testing and explicit errors match scientific reproducibility goals.
+  \item The goal is not to beat mature engines just by choosing Rust.
+  \item The goal is a safe, modular, maintainable path from research prototype to serious simulation software.
 \end{itemize}
+\end{frame}
+
+\begin{frame}{Rust advantage 1: memory safety without GC}
+\begin{itemize}
+  \item MD engines manipulate large arrays of positions, velocities, forces, neighbor lists, cell lists, bonds, and topology.
+  \item C/C++ bugs can include dangling pointers, use-after-free, double free, out-of-bounds access, and invalidated references.
+  \item Rust's ownership and borrowing rules catch many of these hazards at compile time.
+  \item Example MD hazard: mutating a particle array while another part of the code still holds references into it.
+\end{itemize}
+\begin{block}{Why this matters}
+Force loops, neighbor-list builds, integration, and boundary-condition updates are all mutation-heavy and aliasing-sensitive.
+\end{block}
+\end{frame}
+
+\begin{frame}{Rust advantage 2: safer parallelism}
+\begin{itemize}
+  \item MD wants parallelism in pair forces, domain decomposition, neighbor-list builds, reductions, and trajectory analysis.
+  \item The danger is two threads accidentally writing the same force entry or sharing mutable state unsafely.
+  \item Rust forces shared mutation to be explicit: locks, atomics, chunked mutable slices, or safe parallel iterators.
+  \item Good MD designs usually avoid ``mutex everywhere'':
+  \begin{itemize}
+    \item each worker owns a particle chunk, or
+    \item each worker writes to its own force buffer, then buffers are reduced safely.
+  \end{itemize}
+\end{itemize}
+\end{frame}
+
+\begin{frame}{Rust advantage 3: encode simulation meaning in types}
+\begin{itemize}
+  \item An MD engine is not just math; it is a large state machine.
+  \item State includes box dimensions, cutoffs, thermostat/barostat state, masses, topology, random-number generators, and step counters.
+  \item Rust types can make invalid states harder to represent:
+  \begin{itemize}
+    \item \texttt{Positions}, \texttt{Velocities}, \texttt{Forces}, and \texttt{Masses} instead of anonymous arrays,
+    \item enums for algorithm choices such as no thermostat, Andersen, Berendsen, or Nose--Hoover,
+    \item separate immutable parameters from mutable evolving state.
+  \end{itemize}
+  \item The compiler becomes a strict reviewer when ownership or invariants change.
+\end{itemize}
+\end{frame}
+
+\begin{frame}{Rust advantage 4: tooling and modular architecture}
+\begin{columns}[T]
+\column{0.48\textwidth}
+\textbf{Cargo workflow}
+\begin{itemize}
+  \item \texttt{cargo build}
+  \item \texttt{cargo test}
+  \item \texttt{cargo bench}
+  \item \texttt{cargo doc}
+  \item \texttt{cargo fmt} and \texttt{cargo clippy}
+\end{itemize}
+
+\column{0.48\textwidth}
+\textbf{Engine design}
+\begin{itemize}
+  \item traits for force fields, integrators, and thermostats
+  \item feature flags for MPI, viewer, Python, or future GPU paths
+  \item unit tests for forces and regression tests for energy behavior
+  \item clean APIs instead of one giant procedural script
+\end{itemize}
+\end{columns}
+\end{frame}
+
+\begin{frame}{Rust advantage 5: FFI and research workflows}
+\begin{itemize}
+  \item Rust can interoperate with C, C++, Python, MPI libraries, and existing visualization or analysis tools.
+  \item A practical architecture is:
+  \begin{itemize}
+    \item Rust core engine for simulation kernels,
+    \item Python interface for setup, analysis, and experimentation,
+    \item file-format compatibility for tools such as VMD.
+  \end{itemize}
+  \item This supports a research workflow: prototype quickly, test carefully, and keep the performance-critical core compiled and typed.
+\end{itemize}
+\end{frame}
+
+\begin{frame}{Where C++ still has advantages}
+\begin{itemize}
+  \item C++ has a larger and older HPC ecosystem.
+  \item CUDA/HIP and GPU tooling are more mature in C++ workflows.
+  \item Many scientific developers already know C++.
+  \item Existing engines such as GROMACS, LAMMPS, NAMD, AMBER, and OpenMM have decades of optimization and validation.
+\end{itemize}
+\begin{block}{Positioning FerrumMD}
+FerrumMD should be pitched as a modern, safe, modular research engine---not as faster than mature production engines simply because it uses Rust.
+\end{block}
+\end{frame}
+
+\begin{frame}{How to read the codebase as a newcomer}
+\begin{enumerate}
+  \item Start with a runnable example to see the input, loop, and output flow.
+  \item Inspect the state and molecule modules to understand stored data.
+  \item Follow one force calculation from inputs to resulting forces and energy.
+  \item Then look at integrators, ensembles, and I/O formats.
+\end{enumerate}
+\begin{block}{Tip}
+You do not need to understand every force-field detail before contributing to tooling, tests, examples, or documentation.
+\end{block}
 \end{frame}
 
 \begin{frame}{Roadmap and open opportunities}
 \begin{itemize}
-  \item Rigid-water constraints (SETTLE/SHAKE-RATTLE path).
-  \item Topology-correct nonbonded exclusions/pairs.
-  \item Electrostatics and units audit for production TIP3P fidelity.
-  \item Possible Rust-focused contributions:
+  \item Rigid-water constraints such as SETTLE or SHAKE/RATTLE.
+  \item Topology-correct nonbonded exclusions and special pairs.
+  \item Electrostatics and units audits for stronger TIP3P fidelity.
+  \item Rust-focused opportunities:
   \begin{itemize}
-    \item SIMD kernel specialization,
-    \item domain decomposition beyond demo MPI,
-    \item property-based tests for invariants,
-    \item GPU offload experimentation.
+    \item clearer examples and validation tests,
+    \item SIMD or GPU experiments,
+    \item stronger parallel decomposition beyond demo MPI,
+    \item property-based tests for physical invariants.
   \end{itemize}
 \end{itemize}
 \end{frame}
 
-\begin{frame}{Takeaways for Rust developers}
+\begin{frame}{Takeaways}
 \begin{enumerate}
-  \item FerrumMD already demonstrates an end-to-end MD stack in Rust.
-  \item The project is a strong playground for systems + scientific computing ideas.
-  \item You can contribute without deep prior MD experience by starting from architecture and tooling modules.
+  \item MD is a repeated loop: compute forces, update motion, save observations.
+  \item FerrumMD provides an approachable Rust implementation of that loop and its surrounding workflow.
+  \item New contributors can start with examples, units, I/O, tests, and documentation before tackling advanced physics.
 \end{enumerate}
 \vspace{0.8em}
 \centering


### PR DESCRIPTION
### Motivation
- Make the FerrumMD audience slide deck more approachable for newcomers by reframing the talk as a gentle introduction to MD and Rust.
- Clarify the project scope, learning and engineering value, and practical workflows rather than a terse architecture summary.
- Highlight Rust-specific design advantages (safety, parallelism, typing, tooling, FFI) and position FerrumMD as a research-friendly engine.

### Description
- Updated the presentation source file `latex/ferrummd_rust_audience_beamer.tex` with a new title and subtitle and extensive slide rewrites and reorganizations. 
- Replaced high-level architecture and terse bullet lists with newcomer-friendly slides: `Who this talk is for`, `What problem does molecular dynamics solve?`, `MD in one minute`, glossary, `FerrumMD at a glance`, and expanded `Forces`, `Time stepping`, and `Temperature, pressure, and ensembles` sections. 
- Introduced a multi-part Rust-focused sequence (`Rust advantage 1`..`5`) covering memory safety, safer parallelism, expressive types, tooling/architecture, and FFI/workflows, and added `Cargo workflow` and `Engine design` details. 
- Reworked I/O, C++ comparison, roadmap, and takeaways slides and added an explicit `Unit convention` block and practical guidance for new contributors. 

### Testing
- Compiled the updated LaTeX source with `pdflatex` to confirm the beamer document builds without errors, and the compilation succeeded.
- No additional automated tests were run on the slide source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1857d4e980832eb1d1c4e10ff40471)